### PR TITLE
Add GitHub Actions workflows for automated VPS deployment

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,0 +1,28 @@
+name: Deploy Backend
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "backend/**"
+      - "openkoutsi/**"
+      - "pyproject.toml"
+      - "uv.lock"
+
+jobs:
+  deploy:
+    name: Deploy Backend to VPS
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.VPS_SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -H "${{ secrets.VPS_HOST }}" >> ~/.ssh/known_hosts
+
+      - name: Deploy backend
+        run: bash scripts/deploy-backend.sh "${{ secrets.VPS_HOST }}" "${{ secrets.VPS_USER }}"

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,0 +1,35 @@
+name: Deploy Frontend
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "frontend/**"
+
+jobs:
+  deploy:
+    name: Deploy Frontend to VPS
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Set up SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.VPS_SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -H "${{ secrets.VPS_HOST }}" >> ~/.ssh/known_hosts
+
+      - name: Deploy frontend
+        env:
+          NEXT_PUBLIC_API_URL: ${{ secrets.NEXT_PUBLIC_API_URL }}
+          NEXT_PUBLIC_BASE_URL: ${{ secrets.NEXT_PUBLIC_BASE_URL }}
+        run: bash scripts/deploy-frontend.sh "${{ secrets.VPS_HOST }}" "${{ secrets.VPS_USER }}"

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -263,6 +263,37 @@ Check logs with `journalctl -u openkoutsi-backend@$(whoami) -f` (replace the uni
 
 ---
 
+## 7. Automated Deployment (GitHub Actions)
+
+Pushes to `main` trigger automatic deployment via two separate workflows:
+
+- **Deploy Backend** — runs when `backend/`, `openkoutsi/`, `pyproject.toml`, or `uv.lock` change
+- **Deploy Frontend** — runs when `frontend/` changes
+
+### Required GitHub Secrets
+
+Set these under **Settings → Secrets and variables → Actions** in the repository:
+
+| Secret | Description |
+|--------|-------------|
+| `VPS_SSH_PRIVATE_KEY` | Private SSH key whose public key is in `~/.ssh/authorized_keys` on the VPS |
+| `VPS_HOST` | VPS hostname or IP address |
+| `VPS_USER` | Username on the VPS (must match the `@<user>` in the systemd service names) |
+| `NEXT_PUBLIC_API_URL` | API base URL baked into the frontend build (e.g. `https://api.your-domain`) |
+| `NEXT_PUBLIC_BASE_URL` | Frontend base URL baked into the frontend build (e.g. `https://your-domain`) |
+
+### VPS prerequisite: passwordless sudo for systemctl
+
+The deployment scripts run `sudo systemctl` over SSH. The deploy user must be allowed to do so without a password prompt. Create `/etc/sudoers.d/openkoutsi-deploy` on the VPS:
+
+```
+<deploy-user> ALL=(ALL) NOPASSWD: /bin/systemctl stop openkoutsi-backend@*.service, /bin/systemctl start openkoutsi-backend@*.service, /bin/systemctl stop openkoutsi-frontend@*.service, /bin/systemctl start openkoutsi-frontend@*.service, /bin/systemctl daemon-reload
+```
+
+Replace `<deploy-user>` with the actual username. Verify with `sudo visudo -c` after saving.
+
+---
+
 ## Checklist
 
 - [ ] `SECRET_KEY` set to a strong random value
@@ -271,6 +302,8 @@ Check logs with `journalctl -u openkoutsi-backend@$(whoami) -f` (replace the uni
 - [ ] `FRONTEND_URL` and `API_URL` point to real domains
 - [ ] `NEXT_PUBLIC_API_URL` in `frontend/.env.local` points to the API
 - [ ] TLS termination in place for both frontend and API
+- [ ] GitHub Actions secrets set (`VPS_SSH_PRIVATE_KEY`, `VPS_HOST`, `VPS_USER`, `NEXT_PUBLIC_API_URL`, `NEXT_PUBLIC_BASE_URL`) if using automated deployment
+- [ ] VPS deploy user has passwordless sudo for systemctl (see section 7)
 - [ ] Completed first-run setup wizard (creates first team + admin account)
 - [ ] Strava app callback domain updated to production domain (if using Strava)
 - [ ] Wahoo webhook URL registered in the developer portal (if using Wahoo)

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ NEXT_PUBLIC_API_URL=http://localhost:8000
 - **Strava:** configure Strava app credentials in `.env` and deploy `strava_bridge/` to a public HTTPS URL.
 - **Wahoo:** configure Wahoo credentials in `.env` and deploy `wahoo_bridge/` to a public HTTPS URL.
 
-Detailed production setup, reverse proxy examples, systemd units, and bridge registration steps are in [DEPLOY.md](DEPLOY.md).
+Detailed production setup, reverse proxy examples, systemd units, bridge registration steps, and GitHub Actions automated deployment are in [DEPLOY.md](DEPLOY.md).
 
 ## License
 


### PR DESCRIPTION
Adds two separate deploy workflows triggered on push to main:
- deploy-backend.yml: fires on changes to backend/, openkoutsi/, pyproject.toml, uv.lock; SSHes to VPS and runs scripts/deploy-backend.sh
- deploy-frontend.yml: fires on changes to frontend/; builds Next.js standalone on the runner and rsyncs to VPS via scripts/deploy-frontend.sh

Required GitHub secrets: VPS_SSH_PRIVATE_KEY, VPS_HOST, VPS_USER, NEXT_PUBLIC_API_URL, NEXT_PUBLIC_BASE_URL.
Documents the sudoers NOPASSWD requirement for systemctl in DEPLOY.md.

https://claude.ai/code/session_01U3Rg1M4SoBi1U9PSKmPCFQ