### PR TITLE
Fix deploy scripts to include explicit SSH username

### DIFF
--- a/scripts/deploy-backend.sh
+++ b/scripts/deploy-backend.sh
@@ -15,11 +15,11 @@ if [ -z "$USER" ]; then
     exit 1
 fi
 
-ssh "${TARGET}" "sudo -S systemctl stop openkoutsi-backend@${USER}.service"
+ssh "${USER}@${TARGET}" "sudo -S systemctl stop openkoutsi-backend@${USER}.service"
 
-ssh "${TARGET}" "cd projects/openkoutsi && git pull"
-ssh "${TARGET}" "cd projects/openkoutsi && ~/.local/bin/uv run alembic -c backend/alembic-registry.ini upgrade head"
-ssh "${TARGET}" "bash -lc 'cd projects/openkoutsi && ~/.local/bin/uv run python backend/scripts/migrate_teams.py'"
+ssh "${USER}@${TARGET}" "cd projects/openkoutsi && git pull"
+ssh "${USER}@${TARGET}" "cd projects/openkoutsi && ~/.local/bin/uv run alembic -c backend/alembic-registry.ini upgrade head"
+ssh "${USER}@${TARGET}" "bash -lc 'cd projects/openkoutsi && ~/.local/bin/uv run python backend/scripts/migrate_teams.py'"
 
-ssh "${TARGET}" "sudo -S systemctl daemon-reload"
-ssh "${TARGET}" "sudo -S systemctl start openkoutsi-backend@${USER}.service"
+ssh "${USER}@${TARGET}" "sudo -S systemctl daemon-reload"
+ssh "${USER}@${TARGET}" "sudo -S systemctl start openkoutsi-backend@${USER}.service"

--- a/scripts/deploy-frontend.sh
+++ b/scripts/deploy-frontend.sh
@@ -28,11 +28,11 @@ fi
 
 echo "copying to server..."
 
-ssh "${TARGET_SERVER}" "sudo -S systemctl stop openkoutsi-frontend@${USER}.service"
+ssh "${USER}@${TARGET_SERVER}" "sudo -S systemctl stop openkoutsi-frontend@${USER}.service"
 
-rsync -a --delete .next/standalone/ "${TARGET_SERVER}:/home/${USER}/projects/openkoutsi/frontend/.next/standalone/"
+rsync -a --delete .next/standalone/ "${USER}@${TARGET_SERVER}:/home/${USER}/projects/openkoutsi/frontend/.next/standalone/"
 
-ssh "${TARGET_SERVER}" "sudo -S systemctl daemon-reload"
-ssh "${TARGET_SERVER}" "sudo -S systemctl start openkoutsi-frontend@${USER}.service"
+ssh "${USER}@${TARGET_SERVER}" "sudo -S systemctl daemon-reload"
+ssh "${USER}@${TARGET_SERVER}" "sudo -S systemctl start openkoutsi-frontend@${USER}.service"
 
 echo "done..."


### PR DESCRIPTION
## Summary

- Both `scripts/deploy-backend.sh` and `scripts/deploy-frontend.sh` were calling `ssh` and `rsync` with just the hostname, relying on a local `~/.ssh/config` to supply the username
- In GitHub Actions (no SSH config present), this caused connections to go out as the `runner` OS user, resulting in `Permission denied (publickey)`
- Fix: explicitly use `${USER}@${TARGET}` / `${USER}@${TARGET_SERVER}` in all SSH and rsync calls in both scripts

## Test plan

- [ ] Merge and verify the next deploy workflow run connects successfully and reaches the `systemctl` commands on the VPS

https://claude.ai/code/session_01U3Rg1M4SoBi1U9PSKmPCFQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01U3Rg1M4SoBi1U9PSKmPCFQ)_