### PR TITLE
Cycling-themed 404 page (text only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Most cycling coaching tools are cloud-only SaaS. openkoutsi is different: you ru
 - **Structured workouts** — create interval workouts and export as Zwift `.zwo` or FIT workout files for head units
 - **AI coaching analysis** — per-activity analysis and plan support with OpenAI-compatible backends
 - **Privacy-first** — export your data and delete your account at any time
+- **Cycling-themed 404 page** — localized "Wrong Turn!" not-found page with cycling flavour
 
 ## Architecture
 

--- a/frontend/messages/en/common.json
+++ b/frontend/messages/en/common.json
@@ -26,5 +26,10 @@
     "title": "Swapping the Cassette",
     "description": "We're doing a quick mechanical. The server will be back on the road shortly.",
     "retry": "Try again"
+  },
+  "notFound": {
+    "title": "Wrong Turn!",
+    "description": "Oops, looks like you took the wrong turn. This route doesn't exist — head back and find the right trail.",
+    "home": "Back to the peloton"
   }
 }

--- a/frontend/messages/fi/common.json
+++ b/frontend/messages/fi/common.json
@@ -26,5 +26,10 @@
     "title": "Vaihdetaan kasettia",
     "description": "Pieni huoltotoimenpide. Palvelimen matka jatkuu pian.",
     "retry": "Yritä uudelleen"
+  },
+  "notFound": {
+    "title": "Väärä käänne!",
+    "description": "Hups, näyttää siltä että ajoit väärään suuntaan. Tätä reittiä ei ole — palaa takaisin oikealle reitille.",
+    "home": "Takaisin pelotoniin"
   }
 }

--- a/frontend/src/app/[locale]/not-found.tsx
+++ b/frontend/src/app/[locale]/not-found.tsx
@@ -1,0 +1,23 @@
+import { getTranslations } from 'next-intl/server'
+import Link from 'next/link'
+
+export default async function NotFound() {
+  const t = await getTranslations('common.notFound')
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen gap-6 p-8 text-center">
+      <div className="space-y-3 max-w-sm">
+        <p className="text-6xl font-bold tracking-tight text-muted-foreground/40">404</p>
+        <h1 className="text-2xl font-semibold tracking-tight">{t('title')}</h1>
+        <p className="text-muted-foreground text-sm">{t('description')}</p>
+      </div>
+
+      <Link
+        href="/"
+        className="mt-2 px-4 py-2 rounded-md border text-sm font-medium hover:bg-muted transition-colors"
+      >
+        {t('home')}
+      </Link>
+    </div>
+  )
+}

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,10 +1,15 @@
 export default function NotFound() {
   return (
     <html lang="en">
-      <body style={{ fontFamily: 'sans-serif', textAlign: 'center', paddingTop: '4rem' }}>
-        <h1>404</h1>
-        <p>Page not found</p>
-        <a href="/">Go home</a>
+      <body style={{ fontFamily: 'sans-serif', textAlign: 'center', paddingTop: '6rem' }}>
+        <p style={{ fontSize: '4rem', fontWeight: 'bold', color: '#ccc', margin: 0 }}>404</p>
+        <h1 style={{ fontSize: '1.5rem', marginBottom: '0.5rem' }}>Wrong Turn!</h1>
+        <p style={{ color: '#666', marginBottom: '1.5rem' }}>
+          Oops, looks like you took the wrong turn. This route doesn&apos;t exist.
+        </p>
+        <a href="/" style={{ padding: '0.5rem 1rem', border: '1px solid #ccc', borderRadius: '6px', textDecoration: 'none', color: 'inherit' }}>
+          Back to the peloton
+        </a>
       </body>
     </html>
   )


### PR DESCRIPTION
## Summary

- Replaces the bare "Page not found" 404 page with a cycling-themed "Wrong Turn!" page
- Creates `frontend/src/app/[locale]/not-found.tsx` — a locale-aware server component that uses next-intl so EN and FI users see translated copy
- Updates the root `frontend/src/app/not-found.tsx` (global fallback for invalid locales) with the same cycling-flavoured text in English
- Adds `notFound` translation keys to `messages/en/common.json` and `messages/fi/common.json`

The design follows the existing `MaintenanceView` pattern: centered layout, muted 404 label, heading, description, and a "Back to the peloton" / "Takaisin pelotoniin" home link.

Closes #58

## Test plan

- [ ] Navigate to a nonexistent route under `/en/` — should show "Wrong Turn!" with an English "Back to the peloton" link
- [ ] Navigate to a nonexistent route under `/fi/` — should show "Väärä käänne!" with a Finnish "Takaisin pelotoniin" link
- [ ] Navigate to a completely invalid locale path (e.g. `/xx/foo`) — should fall back to the root not-found page with English text

https://claude.ai/code/session_01Woq89Yt6Eam7uv96ihKgjv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Woq89Yt6Eam7uv96ihKgjv)_