### PR TITLE
Fix training calendar: exclude rest days and distinguish planned vs completed

### DIFF
--- a/frontend/src/__tests__/planUtils.test.ts
+++ b/frontend/src/__tests__/planUtils.test.ts
@@ -169,4 +169,19 @@ describe('groupPlannedWorkoutsByDate', () => {
     expect(map.get('2025-01-15')).toHaveLength(1)
     expect(map.size).toBe(2)
   })
+
+  it('excludes rest days from the map', () => {
+    const plan = makePlan({
+      start_date: '2025-01-06',
+      workouts: [
+        { id: 'w1', plan_id: 'p1', week_number: 1, day_of_week: 1, workout_type: 'rest', description: null, duration_min: null, target_tss: null, completed_activity_id: null },
+        { id: 'w2', plan_id: 'p1', week_number: 1, day_of_week: 2, workout_type: 'endurance', description: null, duration_min: 90, target_tss: 80, completed_activity_id: null },
+      ],
+    })
+
+    const map = groupPlannedWorkoutsByDate(plan)
+    expect(map.size).toBe(1)
+    expect(map.get('2025-01-06')).toBeUndefined()
+    expect(map.get('2025-01-07')).toHaveLength(1)
+  })
 })

--- a/frontend/src/components/activities/ActivityCalendar.tsx
+++ b/frontend/src/components/activities/ActivityCalendar.tsx
@@ -89,7 +89,7 @@ export function ActivityCalendar({ activePlan }: { activePlan?: TrainingPlan }) 
     ? (byDate.get(format(selectedDay, 'yyyy-MM-dd')) ?? [])
     : []
   const selectedPlanned = selectedDay
-    ? (plannedByDate.get(format(selectedDay, 'yyyy-MM-dd')) ?? [])
+    ? (plannedByDate.get(format(selectedDay, 'yyyy-MM-dd')) ?? []).filter((w) => w.completed_activity_id == null)
     : []
 
   function handlePrev() {
@@ -129,7 +129,7 @@ export function ActivityCalendar({ activePlan }: { activePlan?: TrainingPlan }) 
                 {t('calendar.performed')}
               </span>
               <span className="flex items-center gap-1">
-                <span className="h-2 w-2 rounded-full bg-amber-500/80" />
+                <span className="h-2 w-2 rounded-full border border-amber-500/80" />
                 {t('calendar.planned')}
               </span>
             </div>
@@ -181,11 +181,12 @@ export function ActivityCalendar({ activePlan }: { activePlan?: TrainingPlan }) 
                 const planned = plannedByDate.get(key) ?? []
                 const inMonth = isSameMonth(day, currentMonthStart)
                 const hasActivities = activities.length > 0
-                const hasPlanned = planned.length > 0
+                const pendingPlanned = planned.filter((w) => w.completed_activity_id == null)
+                const hasPlanned = pendingPlanned.length > 0
                 const activityBars = activities.slice(0, 2)
-                const plannedBars = planned.slice(0, 2)
+                const plannedBars = pendingPlanned.slice(0, 2)
                 const activityOverflow = activities.length - 2
-                const plannedOverflow = planned.length - 2
+                const plannedOverflow = pendingPlanned.length - 2
 
                 return (
                   <div
@@ -216,14 +217,14 @@ export function ActivityCalendar({ activePlan }: { activePlan?: TrainingPlan }) 
                         {activityBars.map((a) => (
                           <div
                             key={a.id}
-                            className="h-1 w-full rounded-full bg-primary/70"
+                            className="h-1.5 w-full rounded-full bg-primary/70"
                             title={a.name}
                           />
                         ))}
                         {plannedBars.map((w) => (
                           <div
                             key={w.id}
-                            className="h-1 w-full rounded-full bg-amber-500/80"
+                            className="h-1.5 w-full rounded-full border border-amber-500/80"
                             title={w.description ?? w.workout_type}
                           />
                         ))}

--- a/frontend/src/lib/planUtils.ts
+++ b/frontend/src/lib/planUtils.ts
@@ -37,6 +37,7 @@ export function groupPlannedWorkoutsByDate(plan: TrainingPlan | undefined): Map<
   if (!plan || plan.status !== 'active') return map
 
   for (const workout of plan.workouts) {
+    if (workout.workout_type === 'rest') continue
     const key = format(workoutDate(plan.start_date, workout.week_number, workout.day_of_week), 'yyyy-MM-dd')
     if (!map.has(key)) map.set(key, [])
     map.get(key)!.push(workout)


### PR DESCRIPTION
## Summary

Fixes two UX problems reported in #53 after the Copilot implementation was merged:

- **Rest days shown as planned workouts** — `groupPlannedWorkoutsByDate` was including every `workout_type: "rest"` entry, giving each rest day an amber-highlighted calendar cell identical to a real planned workout.
- **Hard to distinguish planned vs completed** — both used the same solid filled bar shape; only colour differed.

## Changes

- `planUtils.ts` — skip `workout_type === 'rest'` in `groupPlannedWorkoutsByDate` so rest days are never surfaced in the calendar.
- `ActivityCalendar.tsx`:
  - Planned workout bars are now **outlined** (border-only, no fill) while completed activity bars remain **solid filled** — visually distinct by shape, not just colour.
  - Bars are slightly taller (`h-1.5` vs `h-1`) so the outline is legible.
  - The legend dot in the card header is updated to match (outlined circle for planned).
  - Planned workouts that already have a `completed_activity_id` are filtered out of the bar layer and the day-detail dialog — they are already represented by the completed activity row, so showing them twice was confusing.
- `planUtils.test.ts` — new test asserting that rest-day workouts are excluded from the returned map.

## Test plan

- [ ] Calendar cells for rest days show no amber highlight
- [ ] Days with only planned workouts show outlined amber bars
- [ ] Days with completed activities show solid blue bars
- [ ] Days with both show solid blue bars + outlined amber bars, clearly different
- [ ] A planned workout that has been completed disappears from the planned layer (only shows as a completed activity)
- [ ] Legend dot for "Planned" is an outlined circle
- [ ] `npx vitest run` passes in `frontend/`

https://claude.ai/code/session_01VT29zd4rb1PF886fc5x3wT

---
_Generated by [Claude Code](https://claude.ai/code/session_01VT29zd4rb1PF886fc5x3wT)_