### PR TITLE
Auto-apply detected workout category on activity sync

### DIFF
--- a/backend/app/services/provider_sync.py
+++ b/backend/app/services/provider_sync.py
@@ -37,6 +37,7 @@ from backend.app.models.team_orm import (
     ActivityStream,
     Athlete,
 )
+from openkoutsi.categorization import classify_workout
 from openkoutsi.fit_processing import (
     resolve_sport_type,
     auto_interval_s,
@@ -518,6 +519,10 @@ async def _fill_from_source(
             activity.intensity_factor = intensity_factor
             activity.status = "processed"
 
+            vi = (np_val / activity.avg_power) if (np_val and activity.avg_power) else None
+            category = classify_workout(intensity_factor, vi)
+            activity.workout_category = category.value if category else None
+
             _add_streams(
                 activity, session, power_data, hr_data, cadence_data, speed_ms, alt_data
             )
@@ -587,6 +592,10 @@ async def _fill_from_source(
     activity.tss = tss
     activity.intensity_factor = intensity_factor
     activity.status = "processed"
+
+    vi = (np_val / activity.avg_power) if (np_val and activity.avg_power) else None
+    category = classify_workout(intensity_factor, vi)
+    activity.workout_category = category.value if category else None
 
     _add_streams(
         activity, session, power_data, hr_data, cadence_data, speed_data, altitude_data

--- a/tests/unit/test_provider_sync.py
+++ b/tests/unit/test_provider_sync.py
@@ -539,3 +539,101 @@ class TestSyncProviderActivities:
 
         assert count == 3
         assert mock_client.list_activities.call_count == 3
+
+    async def test_auto_category_assigned_from_stream_data(self, session):
+        """workout_category is auto-assigned when power streams are available."""
+        athlete = await _make_athlete(session, user_id="user-11")
+        athlete.ftp = 250
+        await session.commit()
+
+        conn = _make_connection(athlete)
+
+        mock_client = MagicMock()
+        mock_client.list_activities = AsyncMock(side_effect=[[_norm()], []])
+        mock_client.download_fit_file = AsyncMock(side_effect=Exception("no FIT"))
+        # 3600 samples at 200 W → IF = 200/250 = 0.80 → "tempo"
+        mock_client.get_activity_streams = AsyncMock(
+            return_value={"power": [200] * 3600}
+        )
+        mock_cls = MagicMock(return_value=mock_client)
+
+        with patch("backend.app.services.provider_sync.PROVIDERS", {"strava": mock_cls}):
+            await sync_provider_activities(
+                athlete, conn, session, team_id=_TEAM_ID, access_token=_ACCESS_TOKEN
+            )
+
+        act = (await session.execute(
+            select(Activity).where(Activity.athlete_id == athlete.id)
+        )).scalar_one()
+        assert act.workout_category == "tempo"
+
+    async def test_auto_category_assigned_from_fit_file(self, session):
+        """workout_category is auto-assigned when a FIT file is processed during sync."""
+        athlete = await _make_athlete(session, user_id="user-12")
+        athlete.ftp = 250
+        await session.commit()
+
+        conn = _make_connection(athlete, provider="wahoo")
+        base_time = datetime(2024, 8, 1, 9, 0, tzinfo=timezone.utc)
+
+        fit_bytes = b"fakeFITdata"
+        wahoo_mock = MagicMock()
+        wahoo_mock.list_activities = AsyncMock(side_effect=[[_norm("wahoo-1", "wahoo", base_time)], []])
+        wahoo_mock.download_fit_file = AsyncMock(return_value=fit_bytes)
+        wahoo_cls = MagicMock(return_value=wahoo_mock)
+
+        fake_profile = MagicMock()
+        # 3600 samples at 225 W → IF = 225/250 = 0.90 → "threshold"
+        fake_profile.power = [225] * 3600
+        fake_profile.heartRate = []
+        fake_profile.cadence = []
+        fake_profile.speed = []
+        fake_profile.altitude = []
+        fake_profile.avgHeartRate = None
+        fake_profile.peakHR = None
+        fake_profile.avgPower = 225.0
+        fake_profile.avgCadence = 0
+        fake_profile.avgSpeed = 0
+        fake_profile.duration = 3600
+        fake_profile.distance = 50000
+        fake_profile.elevationGain = 500
+        fake_profile.start_time = base_time
+        fake_profile.sport_type = "cycling"
+
+        with (
+            patch("backend.app.services.provider_sync.PROVIDERS", {"wahoo": wahoo_cls}),
+            patch("backend.app.services.provider_sync.summarizeWorkout", return_value=fake_profile),
+            patch("backend.app.services.provider_sync.encrypt_file"),
+        ):
+            await sync_provider_activities(
+                athlete, conn, session, team_id=_TEAM_ID, access_token=_ACCESS_TOKEN
+            )
+
+        act = (await session.execute(
+            select(Activity).where(Activity.athlete_id == athlete.id)
+        )).scalar_one()
+        assert act.workout_category == "threshold"
+
+    async def test_no_category_when_no_power_data(self, session):
+        """workout_category stays None when there is no power data to classify from."""
+        athlete = await _make_athlete(session, user_id="user-13")
+        athlete.ftp = 250
+        await session.commit()
+
+        conn = _make_connection(athlete)
+
+        mock_client = MagicMock()
+        mock_client.list_activities = AsyncMock(side_effect=[[_norm()], []])
+        mock_client.download_fit_file = AsyncMock(side_effect=Exception("no FIT"))
+        mock_client.get_activity_streams = AsyncMock(return_value={})  # no power
+        mock_cls = MagicMock(return_value=mock_client)
+
+        with patch("backend.app.services.provider_sync.PROVIDERS", {"strava": mock_cls}):
+            await sync_provider_activities(
+                athlete, conn, session, team_id=_TEAM_ID, access_token=_ACCESS_TOKEN
+            )
+
+        act = (await session.execute(
+            select(Activity).where(Activity.athlete_id == athlete.id)
+        )).scalar_one()
+        assert act.workout_category is None


### PR DESCRIPTION
Fixes #60

## Summary

- The FIT upload path already auto-categorized workouts via `classify_workout` in `fit_processor.py`, but the provider sync pipeline (`provider_sync.py`) did not.
- Both the FIT-first path and the stream-based fallback inside `_fill_from_source` now call `classify_workout(intensity_factor, variability_index)` after computing metrics, mirroring the upload flow exactly.
- Manual override via `PATCH /activities/{id}` is unchanged — users can still change the category after it has been auto-assigned.

## Test plan

- [ ] `test_auto_category_assigned_from_stream_data` — syncing via Strava streams (200 W, FTP=250 → IF=0.80 → `tempo`)
- [ ] `test_auto_category_assigned_from_fit_file` — syncing via Wahoo FIT file (225 W, FTP=250 → IF=0.90 → `threshold`)
- [ ] `test_no_category_when_no_power_data` — no power data → `workout_category` stays `None`
- [ ] All existing `TestSyncProviderActivities` tests still pass

https://claude.ai/code/session_019gqDK7hWrpgaAProYzLahe

---
_Generated by [Claude Code](https://claude.ai/code/session_019gqDK7hWrpgaAProYzLahe)_