### PR TITLE
fix: commit inside asyncio lock to prevent dedup race condition (#76)

### DIFF
--- a/backend/app/services/provider_sync.py
+++ b/backend/app/services/provider_sync.py
@@ -219,10 +219,16 @@ async def sync_provider_activities(
                 continue
 
             # ── Find-or-create under a per-athlete lock ───────────────────
-            # The lock serialises the dedup window query + create/attach so
-            # that two concurrent syncs (e.g. Wahoo webhook + Strava full
-            # sync firing within milliseconds) cannot both see "no existing
-            # activity" and each create a duplicate record.
+            # The lock serialises the dedup window query + commit so that two
+            # concurrent syncs (e.g. Wahoo webhook + Strava full sync firing
+            # within milliseconds) cannot both see "no existing activity" and
+            # each create a duplicate record.
+            #
+            # Critical invariant: the new Activity row must be COMMITTED before
+            # this lock is released.  A flush alone is not sufficient — under
+            # READ COMMITTED isolation (and SQLite WAL mode) another session
+            # that acquires the lock after the flush but before the commit will
+            # still see an empty dedup window and create a duplicate.
             async with _get_activity_lock(team_id, athlete.id):
                 # ── Activity within the time window? ──────────────────────
                 if norm.start_time is not None:
@@ -328,9 +334,14 @@ async def sync_provider_activities(
                 session.add(src)
                 await session.flush()
 
+                # Commit inside the lock so the Activity is visible to any
+                # concurrent session that next acquires the lock and queries
+                # the dedup window.  _populate_activity will update the row
+                # again (metrics, streams, status) and commit a second time.
+                await session.commit()
+
             # FIT download and stream processing happen outside the lock —
-            # they are slow network/IO operations that don't touch the
-            # find-or-create critical section.
+            # they are slow I/O operations that don't need to be serialised.
             await _populate_activity(
                 activity, src, norm, client, access_token, athlete, session, team_id=team_id
             )

--- a/backend/app/services/strava_sync.py
+++ b/backend/app/services/strava_sync.py
@@ -235,6 +235,10 @@ async def _process_event_for_team(
             session.add(src)
             await session.flush()
 
+            # Commit inside the lock so the Activity is visible to concurrent
+            # sessions before this lock is released (fixes the #76 race condition).
+            await session.commit()
+
         await _populate_activity(
             activity, src, norm, _strava_client, access_token,
             athlete, session, team_id=team_id,

--- a/backend/app/services/wahoo_sync.py
+++ b/backend/app/services/wahoo_sync.py
@@ -220,6 +220,10 @@ async def _process_wahoo_for_team(norm, athlete, conn, access_token, team_id, se
         session.add(src)
         await session.flush()
 
+        # Commit inside the lock so the Activity is visible to concurrent
+        # sessions before this lock is released (fixes the #76 race condition).
+        await session.commit()
+
     prefetched_fit_new: bytes | None = None
     try:
         prefetched_fit_new = await _download_fit_cdn_first(

--- a/tests/unit/test_provider_sync.py
+++ b/tests/unit/test_provider_sync.py
@@ -647,22 +647,22 @@ class TestSyncProviderActivities:
 
 class TestDeduplicationRaceCondition:
     """
-    Regression tests for the cross-session dedup race condition reported in #76.
+    Tests for the cross-session dedup race condition reported in #76.
 
-    Root cause summary
-    ------------------
+    Root cause
+    ----------
     The asyncio lock in provider_sync serialises the dedup-window query + flush
-    *within a single process*, but it releases before the database transaction
-    commits.  Under READ COMMITTED isolation (PostgreSQL production, and SQLite
-    with separate connections), a second session that acquires the lock after the
-    first one has *flushed but not committed* will see an empty dedup window and
-    create a duplicate Activity.
+    *within a single process*, but it used to release before the database
+    transaction committed.  Under READ COMMITTED isolation (and SQLite WAL mode),
+    a second session that acquired the lock after the first had flushed-but-not-
+    committed would see an empty dedup window and create a duplicate Activity.
 
-    Why existing tests missed it
-    ----------------------------
-    All previous dedup tests run two provider syncs *sequentially* — the first
-    call completes and commits before the second starts.  No test exercised the
-    concurrent path where both sessions are alive at the same time.
+    Fix
+    ---
+    ``await session.commit()`` is now called inside the asyncio lock for the
+    "new workout" path in provider_sync.py, wahoo_sync.py, and strava_sync.py.
+    The commit makes the new Activity visible to other sessions before the lock
+    is released, closing the window entirely.
 
     Why a file-based engine is required here
     ----------------------------------------
@@ -671,7 +671,7 @@ class TestDeduplicationRaceCondition:
     A file-based database allows multiple connections to the same database, which
     is what we need to observe the cross-session isolation behaviour.
     SQLite's single-writer semantics still apply, but the observable outcome
-    (two committed Activity rows) faithfully reproduces the PostgreSQL race.
+    faithfully reproduces the PostgreSQL race.
     """
 
     @pytest.fixture
@@ -689,32 +689,15 @@ class TestDeduplicationRaceCondition:
         yield eng
         await eng.dispose()
 
-    async def test_concurrent_webhooks_create_duplicate_activity(self, race_engine):
+    async def test_flush_without_commit_allows_race(self, race_engine):
         """
-        Demonstrates the #76 race condition: two simultaneous webhook events
-        produce two Activity records for the same real-world workout.
+        Documents the isolation problem: releasing the lock after a flush (but
+        before the commit) allows a second concurrent session to see an empty
+        dedup window and create a duplicate Activity.
 
-        Execution timeline
-        ------------------
-        1. ``asyncio.gather`` schedules both tasks; Wahoo runs first.
-        2. Wahoo acquires the asyncio dedup lock, queries (empty DB), INSERTs the
-           Activity, flushes — the write transaction is open, RESERVED lock held
-           on the SQLite file — then **releases the asyncio lock without committing**.
-        3. Strava acquires the asyncio lock and queries.  Wahoo's transaction is
-           still open, so Strava reads the last *committed* state — empty — and
-           decides to create its own Activity.
-        4. Strava's INSERT is blocked by SQLite's single-writer rule (Wahoo still
-           holds the RESERVED lock).  Strava's aiosqlite thread waits; the asyncio
-           event loop is free to run Wahoo's continuation.
-        5. Wahoo commits, releasing the RESERVED lock.
-        6. Strava's INSERT proceeds and commits.
-        7. Result: **two Activity rows** for the same workout — the bug.
-
-        After the fix (commit inside the asyncio lock, or SELECT FOR UPDATE on
-        Athlete), Strava's query at step 3 will find Wahoo's committed Activity
-        and will not create a duplicate.
-
-        This test is expected to **FAIL** with the current code.
+        This test intentionally uses the OLD buggy pattern and asserts that two
+        activities are created, proving the race mechanism is real.  It should
+        always pass regardless of production-code changes.
         """
         from backend.app.services.provider_sync import _DUPLICATE_WINDOW, _get_activity_lock
 
@@ -722,17 +705,14 @@ class TestDeduplicationRaceCondition:
         base_time = datetime(2024, 6, 1, 10, 0, tzinfo=timezone.utc)
 
         async with factory() as s:
-            athlete = Athlete(global_user_id="race-user-76", ftp_tests=[])
+            athlete = Athlete(global_user_id="race-flush-user", ftp_tests=[])
             s.add(athlete)
             await s.commit()
             athlete_id = athlete.id
 
-        # Use a unique team_id so the module-level lock dict doesn't retain
-        # state from other test runs.
-        team_id = f"race-team-{athlete_id}"
+        team_id = f"race-flush-{athlete_id}"
 
-        async def wahoo_task() -> None:
-            """Wahoo webhook path: flush inside lock, commit outside (the bug)."""
+        async def first_task() -> None:
             async with factory() as s:
                 async with _get_activity_lock(team_id, athlete_id):
                     r = await s.execute(
@@ -750,15 +730,11 @@ class TestDeduplicationRaceCondition:
                             status="pending",
                         ))
                         await s.flush()
-                # asyncio lock released here — Strava can now enter the lock.
-                # BUG: the transaction is not committed yet; Strava's dedup
-                # query will see an empty database.
+                # Lock released here WITHOUT committing — this is the bug.
                 await s.commit()
 
-        async def strava_task() -> None:
-            """Strava webhook path: runs concurrently, loses the race."""
-            # Yield once so Wahoo starts first and acquires the asyncio lock.
-            await asyncio.sleep(0)
+        async def second_task() -> None:
+            await asyncio.sleep(0)  # yield so first_task acquires the lock first
             async with factory() as s:
                 async with _get_activity_lock(team_id, athlete_id):
                     r = await s.execute(
@@ -768,8 +744,6 @@ class TestDeduplicationRaceCondition:
                             Activity.start_time <= base_time + _DUPLICATE_WINDOW,
                         )
                     )
-                    # Under the race: Wahoo has flushed but not committed, so
-                    # this query returns None and Strava creates a duplicate.
                     if r.scalar_one_or_none() is None:
                         s.add(Activity(
                             athlete_id=athlete_id,
@@ -780,7 +754,84 @@ class TestDeduplicationRaceCondition:
                         await s.flush()
                 await s.commit()
 
-        await asyncio.gather(wahoo_task(), strava_task())
+        await asyncio.gather(first_task(), second_task())
+
+        async with factory() as s:
+            r = await s.execute(select(Activity).where(Activity.athlete_id == athlete_id))
+            activities = r.scalars().all()
+
+        # Demonstrates the race: flush-without-commit leaves a window that the
+        # second session exploits, producing a duplicate row.
+        assert len(activities) == 2, (
+            f"Expected 2 (race condition produces a duplicate) but got {len(activities)}. "
+            "If this fails the SQLite busy-timeout may have serialised the writes "
+            "differently than expected."
+        )
+
+    async def test_commit_inside_lock_prevents_race(self, race_engine):
+        """
+        Regression test for #76: committing inside the asyncio lock ensures that
+        the new Activity is visible to any concurrent session before the lock is
+        released, so the second session finds the existing Activity and does not
+        create a duplicate.
+        """
+        from backend.app.services.provider_sync import _DUPLICATE_WINDOW, _get_activity_lock
+
+        factory = async_sessionmaker(race_engine, expire_on_commit=False)
+        base_time = datetime(2024, 6, 1, 10, 0, tzinfo=timezone.utc)
+
+        async with factory() as s:
+            athlete = Athlete(global_user_id="race-fix-user", ftp_tests=[])
+            s.add(athlete)
+            await s.commit()
+            athlete_id = athlete.id
+
+        team_id = f"race-fix-{athlete_id}"
+
+        async def first_task() -> None:
+            async with factory() as s:
+                async with _get_activity_lock(team_id, athlete_id):
+                    r = await s.execute(
+                        select(Activity).where(
+                            Activity.athlete_id == athlete_id,
+                            Activity.start_time >= base_time - _DUPLICATE_WINDOW,
+                            Activity.start_time <= base_time + _DUPLICATE_WINDOW,
+                        )
+                    )
+                    if r.scalar_one_or_none() is None:
+                        s.add(Activity(
+                            athlete_id=athlete_id,
+                            start_time=base_time,
+                            duration_s=5010,
+                            status="pending",
+                        ))
+                        await s.flush()
+                    # Fix: commit inside the lock so data is visible before
+                    # any other session acquires the lock.
+                    await s.commit()
+
+        async def second_task() -> None:
+            await asyncio.sleep(0)  # yield so first_task acquires the lock first
+            async with factory() as s:
+                async with _get_activity_lock(team_id, athlete_id):
+                    r = await s.execute(
+                        select(Activity).where(
+                            Activity.athlete_id == athlete_id,
+                            Activity.start_time >= base_time - _DUPLICATE_WINDOW,
+                            Activity.start_time <= base_time + _DUPLICATE_WINDOW,
+                        )
+                    )
+                    if r.scalar_one_or_none() is None:
+                        s.add(Activity(
+                            athlete_id=athlete_id,
+                            start_time=base_time,
+                            duration_s=5009,
+                            status="pending",
+                        ))
+                        await s.flush()
+                    await s.commit()
+
+        await asyncio.gather(first_task(), second_task())
 
         async with factory() as s:
             r = await s.execute(select(Activity).where(Activity.athlete_id == athlete_id))
@@ -789,8 +840,5 @@ class TestDeduplicationRaceCondition:
         assert len(activities) == 1, (
             f"Race condition created {len(activities)} duplicate Activity records "
             f"for the same workout (expected 1). "
-            f"Fix: commit must happen before the asyncio lock is released, or a "
-            f"database-level lock (SELECT FOR UPDATE on Athlete, or a PostgreSQL "
-            f"advisory lock) must be used so the lock lifetime matches the "
-            f"transaction lifetime."
+            f"The asyncio lock must guard both the flush and the commit."
         )

--- a/tests/unit/test_provider_sync.py
+++ b/tests/unit/test_provider_sync.py
@@ -4,12 +4,15 @@ Unit tests for backend.app.services.provider_sync.
 Tests ensure_fresh_token and sync_provider_activities in isolation by mocking
 the PROVIDERS registry so no real HTTP calls are made.
 """
+import asyncio
 from datetime import date, datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
+from backend.app.db.base import TeamBase
 from backend.app.models.team_orm import Activity, ActivitySource, Athlete
 from backend.app.models.registry_orm import ProviderConnection
 from backend.app.services.provider_sync import ensure_fresh_token, sync_provider_activities
@@ -637,3 +640,157 @@ class TestSyncProviderActivities:
             select(Activity).where(Activity.athlete_id == athlete.id)
         )).scalar_one()
         assert act.workout_category is None
+
+
+# ── Dedup race condition (issue #76) ──────────────────────────────────────────
+
+
+class TestDeduplicationRaceCondition:
+    """
+    Regression tests for the cross-session dedup race condition reported in #76.
+
+    Root cause summary
+    ------------------
+    The asyncio lock in provider_sync serialises the dedup-window query + flush
+    *within a single process*, but it releases before the database transaction
+    commits.  Under READ COMMITTED isolation (PostgreSQL production, and SQLite
+    with separate connections), a second session that acquires the lock after the
+    first one has *flushed but not committed* will see an empty dedup window and
+    create a duplicate Activity.
+
+    Why existing tests missed it
+    ----------------------------
+    All previous dedup tests run two provider syncs *sequentially* — the first
+    call completes and commits before the second starts.  No test exercised the
+    concurrent path where both sessions are alive at the same time.
+
+    Why a file-based engine is required here
+    ----------------------------------------
+    ``sqlite+aiosqlite:///:memory:`` gives every aiosqlite connection its own
+    private in-memory database, so separate sessions literally cannot share data.
+    A file-based database allows multiple connections to the same database, which
+    is what we need to observe the cross-session isolation behaviour.
+    SQLite's single-writer semantics still apply, but the observable outcome
+    (two committed Activity rows) faithfully reproduces the PostgreSQL race.
+    """
+
+    @pytest.fixture
+    async def race_engine(self, tmp_path):
+        """File-based SQLite engine shared by multiple concurrent sessions."""
+        db_path = tmp_path / "race.db"
+        eng = create_async_engine(
+            f"sqlite+aiosqlite:///{db_path}",
+            # Allow a short busy-wait so the second writer can proceed once the
+            # first session commits rather than failing immediately.
+            connect_args={"timeout": 10},
+        )
+        async with eng.begin() as conn:
+            await conn.run_sync(TeamBase.metadata.create_all)
+        yield eng
+        await eng.dispose()
+
+    async def test_concurrent_webhooks_create_duplicate_activity(self, race_engine):
+        """
+        Demonstrates the #76 race condition: two simultaneous webhook events
+        produce two Activity records for the same real-world workout.
+
+        Execution timeline
+        ------------------
+        1. ``asyncio.gather`` schedules both tasks; Wahoo runs first.
+        2. Wahoo acquires the asyncio dedup lock, queries (empty DB), INSERTs the
+           Activity, flushes — the write transaction is open, RESERVED lock held
+           on the SQLite file — then **releases the asyncio lock without committing**.
+        3. Strava acquires the asyncio lock and queries.  Wahoo's transaction is
+           still open, so Strava reads the last *committed* state — empty — and
+           decides to create its own Activity.
+        4. Strava's INSERT is blocked by SQLite's single-writer rule (Wahoo still
+           holds the RESERVED lock).  Strava's aiosqlite thread waits; the asyncio
+           event loop is free to run Wahoo's continuation.
+        5. Wahoo commits, releasing the RESERVED lock.
+        6. Strava's INSERT proceeds and commits.
+        7. Result: **two Activity rows** for the same workout — the bug.
+
+        After the fix (commit inside the asyncio lock, or SELECT FOR UPDATE on
+        Athlete), Strava's query at step 3 will find Wahoo's committed Activity
+        and will not create a duplicate.
+
+        This test is expected to **FAIL** with the current code.
+        """
+        from backend.app.services.provider_sync import _DUPLICATE_WINDOW, _get_activity_lock
+
+        factory = async_sessionmaker(race_engine, expire_on_commit=False)
+        base_time = datetime(2024, 6, 1, 10, 0, tzinfo=timezone.utc)
+
+        async with factory() as s:
+            athlete = Athlete(global_user_id="race-user-76", ftp_tests=[])
+            s.add(athlete)
+            await s.commit()
+            athlete_id = athlete.id
+
+        # Use a unique team_id so the module-level lock dict doesn't retain
+        # state from other test runs.
+        team_id = f"race-team-{athlete_id}"
+
+        async def wahoo_task() -> None:
+            """Wahoo webhook path: flush inside lock, commit outside (the bug)."""
+            async with factory() as s:
+                async with _get_activity_lock(team_id, athlete_id):
+                    r = await s.execute(
+                        select(Activity).where(
+                            Activity.athlete_id == athlete_id,
+                            Activity.start_time >= base_time - _DUPLICATE_WINDOW,
+                            Activity.start_time <= base_time + _DUPLICATE_WINDOW,
+                        )
+                    )
+                    if r.scalar_one_or_none() is None:
+                        s.add(Activity(
+                            athlete_id=athlete_id,
+                            start_time=base_time,
+                            duration_s=5010,
+                            status="pending",
+                        ))
+                        await s.flush()
+                # asyncio lock released here — Strava can now enter the lock.
+                # BUG: the transaction is not committed yet; Strava's dedup
+                # query will see an empty database.
+                await s.commit()
+
+        async def strava_task() -> None:
+            """Strava webhook path: runs concurrently, loses the race."""
+            # Yield once so Wahoo starts first and acquires the asyncio lock.
+            await asyncio.sleep(0)
+            async with factory() as s:
+                async with _get_activity_lock(team_id, athlete_id):
+                    r = await s.execute(
+                        select(Activity).where(
+                            Activity.athlete_id == athlete_id,
+                            Activity.start_time >= base_time - _DUPLICATE_WINDOW,
+                            Activity.start_time <= base_time + _DUPLICATE_WINDOW,
+                        )
+                    )
+                    # Under the race: Wahoo has flushed but not committed, so
+                    # this query returns None and Strava creates a duplicate.
+                    if r.scalar_one_or_none() is None:
+                        s.add(Activity(
+                            athlete_id=athlete_id,
+                            start_time=base_time,
+                            duration_s=5009,
+                            status="pending",
+                        ))
+                        await s.flush()
+                await s.commit()
+
+        await asyncio.gather(wahoo_task(), strava_task())
+
+        async with factory() as s:
+            r = await s.execute(select(Activity).where(Activity.athlete_id == athlete_id))
+            activities = r.scalars().all()
+
+        assert len(activities) == 1, (
+            f"Race condition created {len(activities)} duplicate Activity records "
+            f"for the same workout (expected 1). "
+            f"Fix: commit must happen before the asyncio lock is released, or a "
+            f"database-level lock (SELECT FOR UPDATE on Athlete, or a PostgreSQL "
+            f"advisory lock) must be used so the lock lifetime matches the "
+            f"transaction lifetime."
+        )

--- a/tests/unit/test_provider_sync.py
+++ b/tests/unit/test_provider_sync.py
@@ -698,6 +698,15 @@ class TestDeduplicationRaceCondition:
         This test intentionally uses the OLD buggy pattern and asserts that two
         activities are created, proving the race mechanism is real.  It should
         always pass regardless of production-code changes.
+
+        Two asyncio.Event objects gate the ordering deterministically:
+        - first_released_lock: first_task signals it after releasing the asyncio
+          lock (still holding the SQLite RESERVED lock, before commit).
+        - second_has_read: second_task signals it after executing the dedup SELECT
+          but BEFORE its own flush.  Signalling before flush is critical: the flush
+          will block in the aiosqlite background thread (INSERT waits for the
+          RESERVED lock held by first_task).  Signalling first lets first_task
+          proceed to commit, releasing the RESERVED lock and unblocking the INSERT.
         """
         from backend.app.services.provider_sync import _DUPLICATE_WINDOW, _get_activity_lock
 
@@ -711,6 +720,8 @@ class TestDeduplicationRaceCondition:
             athlete_id = athlete.id
 
         team_id = f"race-flush-{athlete_id}"
+        first_released_lock = asyncio.Event()
+        second_has_read = asyncio.Event()
 
         async def first_task() -> None:
             async with factory() as s:
@@ -730,11 +741,18 @@ class TestDeduplicationRaceCondition:
                             status="pending",
                         ))
                         await s.flush()
-                # Lock released here WITHOUT committing — this is the bug.
+                # Lock released WITHOUT committing (the bug).
+                # Signal second_task to acquire the lock and read.
+                first_released_lock.set()
+                # Wait until second_task has read so its SELECT is guaranteed to
+                # land while first_task's RESERVED lock is still held (uncommitted).
+                await second_has_read.wait()
                 await s.commit()
 
         async def second_task() -> None:
-            await asyncio.sleep(0)  # yield so first_task acquires the lock first
+            # Wait until first_task has released the asyncio lock before trying
+            # to acquire it, so ordering is guaranteed.
+            await first_released_lock.wait()
             async with factory() as s:
                 async with _get_activity_lock(team_id, athlete_id):
                     r = await s.execute(
@@ -744,7 +762,13 @@ class TestDeduplicationRaceCondition:
                             Activity.start_time <= base_time + _DUPLICATE_WINDOW,
                         )
                     )
-                    if r.scalar_one_or_none() is None:
+                    found = r.scalar_one_or_none()
+                    # Signal BEFORE flush: the flush blocks in the aiosqlite
+                    # background thread (INSERT waits for first_task's RESERVED
+                    # lock).  Setting the event here lets the event loop run
+                    # first_task → commit → release RESERVED → unblock INSERT.
+                    second_has_read.set()
+                    if found is None:
                         s.add(Activity(
                             athlete_id=athlete_id,
                             start_time=base_time,
@@ -764,8 +788,7 @@ class TestDeduplicationRaceCondition:
         # second session exploits, producing a duplicate row.
         assert len(activities) == 2, (
             f"Expected 2 (race condition produces a duplicate) but got {len(activities)}. "
-            "If this fails the SQLite busy-timeout may have serialised the writes "
-            "differently than expected."
+            "The asyncio.Event gates should make the ordering deterministic."
         )
 
     async def test_commit_inside_lock_prevents_race(self, race_engine):


### PR DESCRIPTION
## Summary

Fixes #76 — duplicate activities created when Wahoo and Strava webhooks arrive simultaneously.

### Root cause

The asyncio lock in `provider_sync` serialised the dedup-window query and `flush()`, but **released before the database transaction committed**. Under SQLite WAL mode (and PostgreSQL READ COMMITTED), a second session that acquired the lock after the first had flushed-but-not-committed would read the last *committed* state — empty — and create a duplicate Activity. The timestamps in #76 confirm this: both records have `created_at` within 400 ms of each other.

```
Wahoo:  created_at 2026-05-26T19:28:09.109917
Strava: created_at 2026-05-26T19:28:09.431209
```

The previous fix (issue #52) added the asyncio lock, which prevents two coroutines in the same process from entering the critical section simultaneously. But it didn't account for the fact that `commit()` happened *after* the lock released, leaving a window where a second session could acquire the lock and see a still-empty dedup window.

### Fix

Call `await session.commit()` **inside** the asyncio lock for the "new workout" path in all three sync entry points:

- `backend/app/services/provider_sync.py` (full sync pipeline)
- `backend/app/services/wahoo_sync.py` (Wahoo webhook)
- `backend/app/services/strava_sync.py` (Strava webhook)

The commit makes the new `Activity` row visible to all other sessions before the lock is released. `_populate_activity` continues to run outside the lock (as before) and issues a second commit to write metrics, streams, and status — this is just an `UPDATE` on the already-committed row and works correctly with `expire_on_commit=False`.

The "attach to existing activity" paths were already correct — they committed inside the lock via `_repopulate_activity` or an explicit `session.commit()`.

### Tests

Two new tests in `TestDeduplicationRaceCondition` use a **file-based SQLite engine** (required because `sqlite+aiosqlite:///:memory:` gives every connection its own private in-memory database, so separate sessions cannot share state):

- `test_flush_without_commit_allows_race` — uses the old buggy pattern (commit outside lock) and asserts that **2** activities are created, proving the race mechanism is real.
- `test_commit_inside_lock_prevents_race` — regression guard that uses the fixed pattern (commit inside lock) and asserts only **1** activity is created.

## Test plan

- [ ] `uv run python -m pytest tests/unit/test_provider_sync.py -v` — all existing dedup tests pass; both new race condition tests pass
- [ ] `uv run python -m pytest tests/` — full suite green
- [ ] Manually verify that a workout synced from both Wahoo and Strava appears as a single activity

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ggmce3SZLytobx74CeeYTy)_