### PR TITLE
Detect and fix stale fitness metrics caused by deleted activities

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Most cycling coaching tools are cloud-only SaaS. openkoutsi is different: you ru
 - **Workout categorization** — automatic Coggan-style zone classification with manual override
 - **Strava + Wahoo sync** — OAuth integrations with history import and webhook updates through bridge services
 - **Zone sync** — sync HR/power zones and FTP from connected providers
-- **Fitness metrics** — CTL/ATL/TSB computed and shown as interactive charts
+- **Fitness metrics** — CTL/ATL/TSB computed and shown as interactive charts; stale metrics caused by deleted activities are detected and corrected automatically on dashboard load
 - **Training calendar** — dashboard calendar shows both performed and planned workouts with distinct visual markers
 - **Training plan generation** — periodized plans (Base → Build → Peak → Taper)
 - **Structured workouts** — create interval workouts and export as Zwift `.zwo` or FIT workout files for head units

--- a/backend/app/services/metrics_engine.py
+++ b/backend/app/services/metrics_engine.py
@@ -6,34 +6,90 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from backend.app.models.team_orm import Activity, DailyMetric
 from openkoutsi.fatigue_metrics import compute_daily_metrics
 
+# How far back to scan for stale metrics caused by deleted activities.
+_STALE_CHECK_DAYS = 90
+
+
+async def _find_stale_from(
+    athlete_id: str, today: date, session: AsyncSession
+) -> date | None:
+    """Return the earliest date where DailyMetric.tss_day doesn't match the
+    sum of Activity.tss for that day, or None if everything is consistent.
+
+    A mismatch indicates activities were deleted (or added) without triggering
+    a metric recalculation — e.g. via direct DB cleanup or dedup tooling.
+    """
+    lookback = today - timedelta(days=_STALE_CHECK_DAYS)
+
+    metrics_result = await session.execute(
+        select(DailyMetric).where(
+            DailyMetric.athlete_id == athlete_id,
+            DailyMetric.date >= lookback,
+        )
+    )
+    stored = {m.date: m.tss_day for m in metrics_result.scalars()}
+    if not stored:
+        return None
+
+    cutoff = datetime.combine(lookback, time.min)
+    acts_result = await session.execute(
+        select(Activity).where(
+            Activity.athlete_id == athlete_id,
+            Activity.start_time >= cutoff,
+            Activity.tss.is_not(None),
+            Activity.status == "processed",
+        )
+    )
+    actual: dict[date, float] = {}
+    for act in acts_result.scalars():
+        if act.start_time is None:
+            continue
+        day = act.start_time.date() if hasattr(act.start_time, "date") else act.start_time
+        actual[day] = actual.get(day, 0.0) + (act.tss or 0.0)
+
+    earliest: date | None = None
+    for day, stored_tss in stored.items():
+        if abs(stored_tss - actual.get(day, 0.0)) > 0.01:
+            if earliest is None or day < earliest:
+                earliest = day
+    return earliest
+
 
 async def catch_up_metrics(athlete_id: str, session: AsyncSession) -> bool:
-    """Fill missing DailyMetric rows up to today using stored Activity.tss.
+    """Fill missing DailyMetric rows up to today and fix any rows made stale
+    by deleted activities.
 
-    Returns True if rows were written, False if already up to date.
+    Returns True if rows were written or corrected, False if already up to date.
     No stream reprocessing — uses stored TSS values only.
     """
     today = date.today()
+    recalc_from: date | None = None
+
     existing = await session.execute(
         select(DailyMetric).where(
             DailyMetric.athlete_id == athlete_id,
             DailyMetric.date == today,
         )
     )
-    if existing.scalar_one_or_none() is not None:
-        return False
+    if existing.scalar_one_or_none() is None:
+        last = await session.execute(
+            select(DailyMetric)
+            .where(DailyMetric.athlete_id == athlete_id)
+            .order_by(DailyMetric.date.desc())
+            .limit(1)
+        )
+        last_metric = last.scalar_one_or_none()
+        recalc_from = (last_metric.date + timedelta(days=1)) if last_metric else today
 
-    last = await session.execute(
-        select(DailyMetric)
-        .where(DailyMetric.athlete_id == athlete_id)
-        .order_by(DailyMetric.date.desc())
-        .limit(1)
-    )
-    last_metric = last.scalar_one_or_none()
-    from_date = (last_metric.date + timedelta(days=1)) if last_metric else today
+    stale_from = await _find_stale_from(athlete_id, today, session)
+    if stale_from is not None:
+        if recalc_from is None or stale_from < recalc_from:
+            recalc_from = stale_from
 
-    await recalculate_from(athlete_id, from_date, session)
-    return True
+    if recalc_from is not None:
+        await recalculate_from(athlete_id, recalc_from, session)
+        return True
+    return False
 
 
 async def recalculate_from(

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -138,7 +138,7 @@ class TestCatchUp:
         session.add(DailyMetric(
             athlete_id=athlete_id,
             date=today,
-            ctl=30.0, atl=35.0, tsb=-5.0, tss_day=60.0,
+            ctl=30.0, atl=35.0, tsb=-5.0, tss_day=0.0,
         ))
         await session.commit()
 

--- a/tests/unit/test_metrics_engine.py
+++ b/tests/unit/test_metrics_engine.py
@@ -11,7 +11,7 @@ import pytest
 from sqlalchemy import select
 
 from backend.app.models.team_orm import Activity, ActivitySource, Athlete, DailyMetric
-from backend.app.services.metrics_engine import recalculate_from
+from backend.app.services.metrics_engine import catch_up_metrics, recalculate_from
 
 # EMA decay constants (same as production)
 K42 = 1 - math.exp(-1 / 42)
@@ -134,3 +134,93 @@ class TestRecalculateFrom:
         assert len(metrics) == 1
         assert metrics[0].tss_day == pytest.approx(0.0)
         assert metrics[0].ctl == pytest.approx(0.0)
+
+
+class TestCatchUpMetrics:
+    async def test_no_update_when_metrics_match_activities(self, session):
+        """No recalculation when stored tss_day matches actual activity TSS."""
+        athlete = await _make_athlete(session)
+        await _make_activity(session, athlete.id, tss=80.0, day=TODAY)
+        await recalculate_from(athlete.id, TODAY, session)
+
+        updated = await catch_up_metrics(athlete.id, session)
+
+        assert updated is False
+
+    async def test_recalculates_when_activity_deleted(self, session):
+        """Detects stale tss_day after an activity is hard-deleted without going
+        through the API endpoint (which would normally trigger _bg_recalculate)."""
+        athlete = await _make_athlete(session)
+        yesterday = TODAY - timedelta(days=1)
+
+        act1 = await _make_activity(session, athlete.id, tss=60.0, day=yesterday)
+        act2 = await _make_activity(session, athlete.id, tss=40.0, day=yesterday)
+        await _make_activity(session, athlete.id, tss=50.0, day=TODAY)
+        await recalculate_from(athlete.id, yesterday, session)
+
+        # Verify initial state: both days correct
+        r = await session.execute(
+            select(DailyMetric).where(
+                DailyMetric.athlete_id == athlete.id,
+                DailyMetric.date == yesterday,
+            )
+        )
+        assert r.scalar_one().tss_day == pytest.approx(100.0)
+
+        # Simulate out-of-band hard delete (bypasses the API delete endpoint)
+        await session.delete(act2)
+        await session.flush()
+
+        # catch_up_metrics should detect the mismatch and fix it
+        updated = await catch_up_metrics(athlete.id, session)
+
+        assert updated is True
+        r2 = await session.execute(
+            select(DailyMetric).where(
+                DailyMetric.athlete_id == athlete.id,
+                DailyMetric.date == yesterday,
+            )
+        )
+        fixed = r2.scalar_one()
+        # tss_day should now reflect only act1's 60 TSS
+        assert fixed.tss_day == pytest.approx(60.0)
+
+    async def test_recalculates_cascade_from_earliest_stale_day(self, session):
+        """When the stale day is before the forward-fill gap, recalculation
+        starts from the stale day so subsequent days are also corrected."""
+        athlete = await _make_athlete(session)
+        two_days_ago = TODAY - timedelta(days=2)
+        yesterday = TODAY - timedelta(days=1)
+
+        act = await _make_activity(session, athlete.id, tss=100.0, day=two_days_ago)
+        await _make_activity(session, athlete.id, tss=50.0, day=yesterday)
+        # Don't create today's metric — forward fill gap exists
+        await recalculate_from(athlete.id, two_days_ago, session)
+
+        # Delete today's metric to simulate the forward-fill gap scenario
+        r = await session.execute(
+            select(DailyMetric).where(
+                DailyMetric.athlete_id == athlete.id,
+                DailyMetric.date == TODAY,
+            )
+        )
+        today_metric = r.scalar_one()
+        await session.delete(today_metric)
+        await session.flush()
+
+        # Also hard-delete the activity from two days ago (stale day is earlier)
+        await session.delete(act)
+        await session.flush()
+
+        updated = await catch_up_metrics(athlete.id, session)
+
+        assert updated is True
+        r3 = await session.execute(
+            select(DailyMetric).where(
+                DailyMetric.athlete_id == athlete.id,
+                DailyMetric.date == two_days_ago,
+            )
+        )
+        fixed = r3.scalar_one()
+        # Activity deleted → tss_day should now be 0
+        assert fixed.tss_day == pytest.approx(0.0)


### PR DESCRIPTION
## Summary

- `catch_up_metrics()` now detects when stored `DailyMetric.tss_day` values don't match the actual sum of `Activity.tss` for that day, indicating activities were deleted outside the normal API path (direct DB cleanup, dedup tooling, etc.)
- A new helper `_find_stale_from()` scans the last 90 days, compares stored vs. actual TSS sums, and returns the earliest mismatched date
- When a stale day is found, `recalculate_from()` is called from that date forward, correcting CTL/ATL/TSB for all affected days
- The stale check is merged with the existing forward-fill logic so a single `recalculate_from()` call handles both gaps and stale rows

## Test plan

- [ ] `TestCatchUpMetrics::test_no_update_when_metrics_match_activities` — returns False when tss_day is already correct (no spurious recalculation)
- [ ] `TestCatchUpMetrics::test_recalculates_when_activity_deleted` — returns True and corrects tss_day after a hard-deleted activity leaves a stale metric
- [ ] `TestCatchUpMetrics::test_recalculates_cascade_from_earliest_stale_day` — when both a stale past day and a forward-fill gap exist, recalculation starts from the earlier date
- [ ] Existing `TestRecalculateFrom` tests continue to pass

https://claude.ai/code/session_01EZGPLkNDu6n1MpjktDx8Ce