### PR TITLE
Add PATCH support to /api/athlete/ endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Most cycling coaching tools are cloud-only SaaS. openkoutsi is different: you ru
 - **Activity labels & notes** — tag activities as "race" or "commute" and add free-text notes (included in AI analysis context)
 - **AI coaching analysis** — per-activity analysis and plan support with OpenAI-compatible backends
 - **Koutsi daily feedback** — dashboard card with LLM-generated daily training status covering load trends, recovery state, plan adherence, and goal progress; auto-triggers after uploads/syncs when enabled
+- **PATCH support on `/api/athlete/`** — athlete profile endpoint now accepts both `PUT` and `PATCH` for partial updates
 - **Privacy-first** — export your data and delete your account at any time
 - **Cycling-themed 404 page** — localized "Wrong Turn!" not-found page with cycling flavour
 

--- a/backend/app/api/athlete.py
+++ b/backend/app/api/athlete.py
@@ -126,6 +126,7 @@ async def get_athlete(
 
 
 @router.put("/", response_model=AthleteResponse)
+@router.patch("/", response_model=AthleteResponse)
 async def update_athlete(
     body: AthleteUpdate,
     ctx_session=Depends(get_ctx_and_session),

--- a/frontend/src/app/[locale]/t/[slug]/(app)/layout.tsx
+++ b/frontend/src/app/[locale]/t/[slug]/(app)/layout.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useParams } from 'next/navigation'
 import { useTranslations, useLocale } from 'next-intl'
 import { usePathname, useRouter } from '@/navigation'
@@ -18,6 +18,7 @@ export default function AppLayout({ children }: { children: ReactNode }) {
   const pathname = usePathname()
   const { slug } = useParams<{ slug: string }>()
   const [navOpen, setNavOpen] = useState(false)
+  const persistedLocaleRef = useRef<string | null>(null)
 
   useEffect(() => {
     if (!loading && !athlete) {
@@ -35,9 +36,13 @@ export default function AppLayout({ children }: { children: ReactNode }) {
     }
   }, [athlete, loading, pathname, router, slug])
 
-  // Persist locale in app_settings so backend jobs (auto-analysis) can use it
+  // Persist locale in app_settings so backend jobs (auto-analysis) can use it.
+  // The ref prevents re-calling PATCH when athlete refreshes for unrelated reasons.
   useEffect(() => {
-    if (athlete && (athlete.app_settings as Record<string, unknown>)?.locale !== locale) {
+    if (!athlete || persistedLocaleRef.current === locale) return
+    persistedLocaleRef.current = locale
+    const stored = (athlete.app_settings as Record<string, unknown>)?.locale
+    if (stored !== locale) {
       apiFetch('/api/athlete/', {
         method: 'PATCH',
         body: JSON.stringify({ app_settings: { locale } }),

--- a/openapi.json
+++ b/openapi.json
@@ -1164,6 +1164,50 @@
             "OAuth2PasswordBearer": []
           }
         ]
+      },
+      "patch": {
+        "tags": [
+          "athlete"
+        ],
+        "summary": "Update Athlete",
+        "operationId": "update_athlete_api_athlete__patch",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AthleteUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AthleteResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
       }
     },
     "/api/athlete/avatar": {

--- a/tests/integration/test_athlete.py
+++ b/tests/integration/test_athlete.py
@@ -78,6 +78,21 @@ class TestUpdateAthlete:
         assert resp.status_code == 401
 
 
+class TestPatchAthlete:
+    async def test_patch_partial_update(self, client, auth_headers):
+        await client.put("/api/athlete/", json={"ftp": 300, "max_hr": 185}, headers=auth_headers)
+        resp = await client.patch("/api/athlete/", json={"name": "Patched Rider"}, headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["name"] == "Patched Rider"
+        assert data["ftp"] == 300
+        assert data["max_hr"] == 185
+
+    async def test_patch_unauthenticated_returns_401(self, client):
+        resp = await client.patch("/api/athlete/", json={"ftp": 300})
+        assert resp.status_code == 401
+
+
 class TestLlmApiKeyHandling:
     """The LLM API key must be encrypted at rest and never returned to the client."""
 


### PR DESCRIPTION
The endpoint previously only handled PUT. Since AthleteUpdate already
makes every field optional, the same handler covers partial updates
semantically — this simply registers it under PATCH as well.

https://claude.ai/code/session_019ea6CsUJBc6gWjAjGpwLUb