### PR TITLE
Don't flag today's unfinished workouts as missed

### DIFF
--- a/backend/app/services/llm_training_status_analyzer.py
+++ b/backend/app/services/llm_training_status_analyzer.py
@@ -59,12 +59,12 @@ adherence to the active training plan (if any), and 1-2 specific recommendations
 for the coming days. Write in plain prose — no markdown headers, no bullet points, \
 no code blocks. Separate each paragraph with a single blank line.
 
-If the athlete is missing planned sessions or not adhering to their training plan, \
+When evaluating training plan adherence, apply these rules:
+- Today's planned workouts that are not yet completed must never be treated as missed. \
+The athlete still has time to complete them. Either assume they will be done later today, \
+or encourage the athlete to get them done — but do not criticise or flag them as missed.
+- Only workouts from previous days count as missed. If past days show incomplete sessions, \
 be direct and stern about it.
-
-The training status report includes the current local time. Use it to judge whether \
-the athlete still has time today to complete any unfinished planned workouts before \
-drawing conclusions about adherence.
 
 Before the feedback paragraphs, output a single line in the format: MOOD:<mood>
 where <mood> is one of: cheer, knowing, neutral, stern.


### PR DESCRIPTION
## Summary

- Koutsi no longer criticises workouts planned for today that haven't been completed yet — the athlete still has time, so Koutsi either assumes they'll be done or encourages the athlete to complete them
- Missed-session feedback is now reserved for previous days only

## Change

Single prompt rule replacement in `_SYSTEM_PROMPT_BASE` (`backend/app/services/llm_training_status_analyzer.py`):

**Before:** vague instruction to "use the current time to judge adherence"

**After:** explicit two-rule policy:
1. Today's incomplete workouts → never flagged as missed; encourage or assume they'll happen
2. Previous days' incomplete workouts → flag and be direct about it

## Test plan

- [ ] Generate feedback in the morning with an unfinished planned workout for today — confirm no complaint about it
- [ ] Generate feedback in the evening after skipping yesterday's workout — confirm Koutsi calls it out
- [ ] CI passes

https://claude.ai/code/session_01Lp2xFCCLvQZqSk2KrxyfR7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lp2xFCCLvQZqSk2KrxyfR7)_