### PR TITLE
Fix Koutsi reporting wrong day of week

### DIFF
--- a/backend/app/services/llm_training_status_analyzer.py
+++ b/backend/app/services/llm_training_status_analyzer.py
@@ -113,7 +113,8 @@ def _build_status_prompt(
 ) -> str:
     today = now.date()
     tz_label = now.strftime("%Z") or "UTC"
-    lines = [f"Training status report — {today.isoformat()}  {now.strftime('%H:%M')} {tz_label}"]
+    day_name = today.strftime("%A")
+    lines = [f"Training status report — {today.isoformat()} ({day_name})  {now.strftime('%H:%M')} {tz_label}"]
 
     if athlete.ftp:
         lines.append(f"Athlete FTP: {athlete.ftp} W")


### PR DESCRIPTION
## Summary

- The LLM status prompt only included the ISO date (`2026-05-30`), leaving Koutsi to compute the weekday itself
- LLMs are unreliable at calendar arithmetic, especially for dates beyond their training cutoff — causing Koutsi to report "Friday" when the date is actually a Saturday
- Fix: explicitly include the weekday name in the prompt header (e.g. `2026-05-30 (Saturday)`)

## Test plan

- [ ] Trigger a training status refresh and confirm Koutsi refers to the correct day of the week
- [ ] Existing tests pass: `uv run python -m pytest tests/`

https://claude.ai/code/session_01AhKYj66icrmbzwoXLG9BEJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01AhKYj66icrmbzwoXLG9BEJ)_