### PR TITLE
Fix app_settings overwrite bug and improve mobile responsiveness

### DIFF
--- a/backend/app/api/athlete.py
+++ b/backend/app/api/athlete.py
@@ -202,7 +202,7 @@ async def update_athlete(
             else:
                 new_settings["llm_api_key_enc"] = None
 
-        athlete.app_settings = new_settings
+        athlete.app_settings = {**(athlete.app_settings or {}), **new_settings}
 
     athlete.updated_at = datetime.now(timezone.utc)
     await session.commit()

--- a/backend/app/api/athlete.py
+++ b/backend/app/api/athlete.py
@@ -202,7 +202,10 @@ async def update_athlete(
             else:
                 new_settings["llm_api_key_enc"] = None
 
-        athlete.app_settings = {**(athlete.app_settings or {}), **new_settings}
+        # Merge into existing settings. Explicit None values are treated as
+        # deletions so callers can remove a key without a full-replace round-trip.
+        merged = {**(athlete.app_settings or {}), **new_settings}
+        athlete.app_settings = {k: v for k, v in merged.items() if v is not None}
 
     athlete.updated_at = datetime.now(timezone.utc)
     await session.commit()

--- a/frontend/src/app/[locale]/superadmin/page.tsx
+++ b/frontend/src/app/[locale]/superadmin/page.tsx
@@ -153,7 +153,7 @@ export default function SuperadminPage() {
   }
 
   return (
-    <div className="mx-auto max-w-5xl space-y-8 p-8">
+    <div className="mx-auto max-w-5xl space-y-8 p-4 sm:p-8">
       <h1 className="text-xl font-semibold">{t('title')}</h1>
 
       {actionError && <p className="text-sm text-destructive">{actionError}</p>}
@@ -164,52 +164,54 @@ export default function SuperadminPage() {
         {teams.length === 0 ? (
           <p className="text-sm text-muted-foreground">{t('noTeams')}</p>
         ) : (
-          <div className="rounded-md border">
-            <div className="grid grid-cols-[2fr_1fr_1fr_1fr_1fr_1fr_auto] gap-x-4 border-b bg-muted/50 px-4 py-2 text-sm font-medium text-muted-foreground">
-              <span>{t('columns.name')}</span>
-              <span>{t('columns.slug')}</span>
-              <span>{t('columns.status')}</span>
-              <span>{t('columns.members')}</span>
-              <span>{t('columns.consent')}</span>
-              <span>{t('columns.created')}</span>
-              <span>{t('columns.actions')}</span>
-            </div>
-            {teams.map((team) => (
-              <div
-                key={team.id}
-                className="grid grid-cols-[2fr_1fr_1fr_1fr_1fr_1fr_auto] items-center gap-x-4 border-b px-4 py-3 last:border-b-0"
-              >
-                <span className="font-medium">{team.name}</span>
-                <span className="font-mono text-sm text-muted-foreground">{team.slug}</span>
-                <span>
-                  <Badge variant={statusBadgeVariant(team.status)}>
-                    {t(`status.${team.status as 'pending' | 'active' | 'rejected'}`)}
-                  </Badge>
-                </span>
-                <span className="text-sm">{team.member_count}</span>
-                <span className="text-sm">
-                  {team.consented_count}/{team.member_count}
-                  {team.consented_count < team.member_count && (
-                    <span className="ml-1 text-destructive/70">
-                      ({team.member_count - team.consented_count} {t('columns.consentPending')})
-                    </span>
-                  )}
-                </span>
-                <span className="text-sm text-muted-foreground">
-                  {new Date(team.created_at).toLocaleDateString()}
-                </span>
-                <div className="flex gap-2">
-                  {team.status !== 'active' && (
-                    <Button size="sm" onClick={() => handleApprove(team)}>
-                      {t('approve')}
-                    </Button>
-                  )}
-                  <Button size="sm" variant="destructive" onClick={() => setDeleteTarget(team)}>
-                    {t('delete')}
-                  </Button>
-                </div>
+          <div className="rounded-md border overflow-x-auto">
+            <div className="min-w-[640px]">
+              <div className="grid grid-cols-[2fr_1fr_1fr_1fr_1fr_1fr_auto] gap-x-4 border-b bg-muted/50 px-4 py-2 text-sm font-medium text-muted-foreground">
+                <span>{t('columns.name')}</span>
+                <span>{t('columns.slug')}</span>
+                <span>{t('columns.status')}</span>
+                <span>{t('columns.members')}</span>
+                <span>{t('columns.consent')}</span>
+                <span>{t('columns.created')}</span>
+                <span>{t('columns.actions')}</span>
               </div>
-            ))}
+              {teams.map((team) => (
+                <div
+                  key={team.id}
+                  className="grid grid-cols-[2fr_1fr_1fr_1fr_1fr_1fr_auto] items-center gap-x-4 border-b px-4 py-3 last:border-b-0"
+                >
+                  <span className="font-medium">{team.name}</span>
+                  <span className="font-mono text-sm text-muted-foreground">{team.slug}</span>
+                  <span>
+                    <Badge variant={statusBadgeVariant(team.status)}>
+                      {t(`status.${team.status as 'pending' | 'active' | 'rejected'}`)}
+                    </Badge>
+                  </span>
+                  <span className="text-sm">{team.member_count}</span>
+                  <span className="text-sm">
+                    {team.consented_count}/{team.member_count}
+                    {team.consented_count < team.member_count && (
+                      <span className="ml-1 text-destructive/70">
+                        ({team.member_count - team.consented_count} {t('columns.consentPending')})
+                      </span>
+                    )}
+                  </span>
+                  <span className="text-sm text-muted-foreground">
+                    {new Date(team.created_at).toLocaleDateString()}
+                  </span>
+                  <div className="flex gap-2">
+                    {team.status !== 'active' && (
+                      <Button size="sm" onClick={() => handleApprove(team)}>
+                        {t('approve')}
+                      </Button>
+                    )}
+                    <Button size="sm" variant="destructive" onClick={() => setDeleteTarget(team)}>
+                      {t('delete')}
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
           </div>
         )}
       </div>
@@ -232,19 +234,19 @@ export default function SuperadminPage() {
                 {user.teams.length === 0 ? (
                   <p className="text-xs text-muted-foreground pl-1">{t('users.noTeams')}</p>
                 ) : (
-                  <div className="space-y-1 pl-1">
+                  <div className="space-y-2 pl-1">
                     {user.teams.map((membership) => (
-                      <div key={membership.team_id} className="flex items-center gap-3 text-sm">
+                      <div key={membership.team_id} className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm">
                         <span className="font-mono text-muted-foreground w-32 shrink-0 truncate">
                           {membership.team_slug}
                         </span>
-                        <span className="text-muted-foreground shrink-0">{membership.team_name}</span>
-                        <div className="flex gap-1 shrink-0">
+                        <span className="text-muted-foreground">{membership.team_name}</span>
+                        <div className="flex gap-1">
                           {membership.roles.map((r) => (
                             <Badge key={r} variant="secondary" className="text-xs">{r}</Badge>
                           ))}
                         </div>
-                        <span className="ml-auto shrink-0">
+                        <span className="sm:ml-auto">
                           {membership.consented_at ? (
                             <span className="text-xs text-muted-foreground">
                               {t('users.consentAccepted')} {new Date(membership.consented_at).toLocaleDateString()}

--- a/frontend/src/app/[locale]/t/[slug]/(app)/admin/page.tsx
+++ b/frontend/src/app/[locale]/t/[slug]/(app)/admin/page.tsx
@@ -132,8 +132,8 @@ function MembersTab({ slug }: { slug: string }) {
           <tr className="border-b text-left text-muted-foreground">
             <th className="pb-2 pr-4 font-medium">{t('members.username')}</th>
             <th className="pb-2 pr-4 font-medium">{t('members.roles')}</th>
-            <th className="pb-2 pr-4 font-medium">{t('members.joinedAt')}</th>
-            <th className="pb-2 pr-4 font-medium">{t('members.consent')}</th>
+            <th className="hidden sm:table-cell pb-2 pr-4 font-medium">{t('members.joinedAt')}</th>
+            <th className="hidden sm:table-cell pb-2 pr-4 font-medium">{t('members.consent')}</th>
             <th className="pb-2 font-medium">{t('members.actions')}</th>
           </tr>
         </thead>
@@ -167,10 +167,10 @@ function MembersTab({ slug }: { slug: string }) {
                   </div>
                 )}
               </td>
-              <td className="py-3 pr-4 text-muted-foreground">
+              <td className="hidden sm:table-cell py-3 pr-4 text-muted-foreground">
                 {new Date(m.joined_at).toLocaleDateString()}
               </td>
-              <td className="py-3 pr-4 text-muted-foreground">
+              <td className="hidden sm:table-cell py-3 pr-4 text-muted-foreground">
                 {m.consented_at
                   ? new Date(m.consented_at).toLocaleDateString()
                   : <span className="text-destructive/70">{t('members.noConsent')}</span>

--- a/frontend/src/app/[locale]/t/[slug]/(app)/dashboard/page.tsx
+++ b/frontend/src/app/[locale]/t/[slug]/(app)/dashboard/page.tsx
@@ -243,9 +243,9 @@ export default function DashboardPage() {
 
       {/* Fitness history chart */}
       <Card>
-        <CardHeader className="flex flex-row items-center justify-between pb-2">
+        <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between pb-2">
           <CardTitle className="text-base">{t('fitnessHistory')}</CardTitle>
-          <div className="flex items-center rounded-md border overflow-hidden text-xs">
+          <div className="flex items-center rounded-md border overflow-hidden text-xs self-start sm:self-auto">
             {PERIOD_OPTIONS.map(({ label, days: d }) => (
               <button
                 key={label}

--- a/frontend/src/app/[locale]/t/[slug]/(app)/power/page.tsx
+++ b/frontend/src/app/[locale]/t/[slug]/(app)/power/page.tsx
@@ -86,9 +86,9 @@ export default function PowerPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <h1 className="text-2xl font-semibold">{t('power.title')}</h1>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           {/* Time range */}
           <div className="flex items-center rounded-md border overflow-hidden text-sm">
             {RANGE_OPTIONS.map(({ label, days }) => (

--- a/frontend/src/app/[locale]/t/[slug]/(app)/profile/page.tsx
+++ b/frontend/src/app/[locale]/t/[slug]/(app)/profile/page.tsx
@@ -242,7 +242,7 @@ export default function ProfilePage() {
   async function handleCoachingStyleChange(value: string) {
     try {
       const current = profile?.app_settings ?? {}
-      const updated = { ...current, coaching_style: value === 'default' ? undefined : value }
+      const updated = { ...current, coaching_style: value === 'default' ? null : value }
       await apiFetch('/api/athlete/', {
         method: 'PUT',
         body: JSON.stringify({ app_settings: updated }),

--- a/frontend/src/components/activities/IntervalsTable.tsx
+++ b/frontend/src/components/activities/IntervalsTable.tsx
@@ -34,8 +34,8 @@ export function IntervalsTable({ intervals }: Props) {
             <tr className="border-b border-border bg-muted/40">
               <th className="px-3 py-2 text-left font-medium text-muted-foreground">#</th>
               <th className="px-3 py-2 text-right font-medium text-muted-foreground">{t('duration')}</th>
-              <th className="px-3 py-2 text-right font-medium text-muted-foreground">{t('avgHr')}</th>
-              <th className="px-3 py-2 text-right font-medium text-muted-foreground">{t('avgPower')}</th>
+              <th className="hidden sm:table-cell px-3 py-2 text-right font-medium text-muted-foreground">{t('avgHr')}</th>
+              <th className="hidden sm:table-cell px-3 py-2 text-right font-medium text-muted-foreground">{t('avgPower')}</th>
               <th className="px-3 py-2 text-right font-medium text-muted-foreground">{t('avgSpeed')}</th>
             </tr>
           </thead>
@@ -44,8 +44,8 @@ export function IntervalsTable({ intervals }: Props) {
               <tr key={iv.interval_number} className="border-b border-border last:border-0 hover:bg-muted/20">
                 <td className="px-3 py-2 text-muted-foreground">{iv.interval_number}</td>
                 <td className="px-3 py-2 text-right tabular-nums">{formatDuration(iv.duration_s)}</td>
-                <td className="px-3 py-2 text-right tabular-nums">{formatHR(iv.avg_hr)}</td>
-                <td className="px-3 py-2 text-right tabular-nums">{formatPower(iv.avg_power)}</td>
+                <td className="hidden sm:table-cell px-3 py-2 text-right tabular-nums">{formatHR(iv.avg_hr)}</td>
+                <td className="hidden sm:table-cell px-3 py-2 text-right tabular-nums">{formatPower(iv.avg_power)}</td>
                 <td className="px-3 py-2 text-right tabular-nums">{formatSpeed(iv.avg_speed_ms)}</td>
               </tr>
             ))}


### PR DESCRIPTION
## Summary

- **Bug fix:** Language switching no longer triggers the onboarding wizard. The backend was replacing `app_settings` wholesale on every PATCH, so persisting the locale after a language change wiped out `onboarding_completed` and all other settings. The fix merges the incoming dict into the existing one.
- **Superadmin page:** Teams grid now scrolls horizontally on mobile instead of overflowing the viewport. Page padding scales down on small screens (`p-4 sm:p-8`). Users list rows now wrap instead of overflowing.
- **Dashboard:** Fitness history card header stacks vertically on mobile so the 7-button period selector doesn't overflow the card.
- **Power page:** Header controls (`flex-wrap`) reflow on narrow screens.
- **Admin members table:** Joined-at and consent-date columns hidden on mobile (`hidden sm:table-cell`), keeping the table usable on small screens.
- **IntervalsTable:** Avg-HR and avg-power columns hidden on mobile to reduce horizontal overflow in the activity detail view.

## Test plan

- [ ] Switch language (EN ↔ FI) while logged in — verify the onboarding wizard does **not** appear and all `app_settings` fields (auto-analyze, LLM config, etc.) are preserved
- [ ] Open each changed page at a narrow viewport (~375px): superadmin, dashboard, power, admin, activity detail — verify no horizontal overflow beyond the intended scroll containers
- [ ] Verify superadmin teams grid scrolls horizontally on mobile rather than breaking layout
- [ ] Verify existing backend tests pass (`uv run python -m pytest tests/`)
- [ ] Verify existing frontend tests pass (`npx vitest run`)

https://claude.ai/code/session_01Fq3rMGd7ed5JKAzas1DwCL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fq3rMGd7ed5JKAzas1DwCL)_