### PR TITLE
Flatten repeat blocks into individual steps in FIT export (#73)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Most cycling coaching tools are cloud-only SaaS. openkoutsi is different: you ru
 - **Training calendar** — dashboard calendar shows both performed and planned workouts with distinct visual markers
 - **Training plan generation** — periodized plans (Base → Build → Peak → Taper)
 - **Activity → plan linking** — uploaded activities are automatically matched to the day's planned workout (sport, TSS ≥ 60%, duration ≥ 60%); manual link/unlink via the plan calendar
-- **Structured workouts** — create interval workouts and export as Zwift `.zwo` or FIT workout files for head units
+- **Structured workouts** — create interval workouts and export as Zwift `.zwo` or FIT workout files for head units (FIT export flattens repeat blocks into individual consecutive steps for reliable display on Wahoo/Garmin devices)
 - **Activity labels & notes** — tag activities as "race" or "commute" and add free-text notes (included in AI analysis context)
 - **AI coaching analysis** — per-activity analysis and plan support with OpenAI-compatible backends
 - **Koutsi daily feedback** — dashboard card with LLM-generated daily training status covering load trends, recovery state, plan adherence, and goal progress; auto-triggers after uploads/syncs when enabled

--- a/openkoutsi/workout_formats/fit_workout.py
+++ b/openkoutsi/workout_formats/fit_workout.py
@@ -37,13 +37,26 @@ _INTENSITY = {
     "other": "ACTIVE",
 }
 
+# Maximum note length devices reliably display; the FIT field is bounded too.
+_FIT_NOTE_MAX = 50
+
 
 def _annotate_rep(step: dict, rep: int, count: int) -> dict:
     """Append a compact ``(#rep/count)`` marker to ``step``'s notes (mutating and
-    returning it) so individual repeats are distinguishable on-device."""
+    returning it) so individual repeats are distinguishable on-device.
+
+    The marker is always kept; if the existing note is long it is truncated so
+    that ``note + " " + marker`` still fits within ``_FIT_NOTE_MAX`` — otherwise
+    the downstream truncation in ``_build_fit_bytes`` would cut the marker off.
+    """
     marker = f"(#{rep}/{count})"
     existing = step.get("notes")
-    step["notes"] = f"{existing} {marker}" if existing else marker
+    if existing:
+        keep = _FIT_NOTE_MAX - len(marker) - 1  # room for a separating space
+        existing = existing[:keep].rstrip() if keep > 0 else ""
+        step["notes"] = f"{existing} {marker}".strip()
+    else:
+        step["notes"] = marker
     return step
 
 
@@ -148,7 +161,7 @@ def _build_fit_bytes(
         msg.intensity = getattr(Intensity, intensity_name, Intensity.ACTIVE)
 
         if step.get("notes"):
-            msg.notes = step["notes"][:50]
+            msg.notes = step["notes"][:_FIT_NOTE_MAX]
 
         builder.add(msg)
 

--- a/openkoutsi/workout_formats/fit_workout.py
+++ b/openkoutsi/workout_formats/fit_workout.py
@@ -6,6 +6,8 @@ Requires the `fit-tool` package (add to pyproject.toml and run `uv sync`).
 
 from __future__ import annotations
 
+import copy
+
 from openkoutsi.workout_formats.base import AbstractWorkoutExporter, ExporterMeta
 
 try:
@@ -36,13 +38,28 @@ _INTENSITY = {
 }
 
 
-def _flatten_steps(steps: list[dict], *, _offset: int = 0) -> list[dict]:
+def _annotate_rep(step: dict, rep: int, count: int) -> dict:
+    """Append a compact ``(#rep/count)`` marker to ``step``'s notes (mutating and
+    returning it) so individual repeats are distinguishable on-device."""
+    marker = f"(#{rep}/{count})"
+    existing = step.get("notes")
+    step["notes"] = f"{existing} {marker}" if existing else marker
+    return step
+
+
+def _flatten_steps(steps: list[dict]) -> list[dict]:
     """
     Linearise the step tree into a flat list suitable for FIT message encoding.
 
-    RepeatBlock is encoded as a special step with duration_type=REPEAT_UNTIL_STEPS_CMPLT,
-    pointing back to the first child step. The repeat step is inserted AFTER the child steps
-    (that is how FIT repeat steps work — they are a "loop back" marker).
+    Repeat blocks are *flattened* — instead of emitting a native FIT
+    REPEAT_UNTIL_STEPS_CMPLT "loop back" marker (which Wahoo devices render
+    incorrectly, see issue #73), each block's children are duplicated
+    ``repeat_count`` times so every interval becomes an independent step. Nested
+    repeats are expanded inner-first. Each duplicated step gets a ``(#rep/count)``
+    marker appended to its notes so reps can be told apart on the device.
+
+    The result is a flat list of ``{"_type": "step", ...}`` dicts in execution
+    order; no repeat markers remain.
     """
     result: list[dict] = []
 
@@ -51,14 +68,14 @@ def _flatten_steps(steps: list[dict], *, _offset: int = 0) -> list[dict]:
         if kind == "step":
             result.append({"_type": "step", **step})
         elif kind == "repeat":
-            children = step.get("steps", [])
-            first_child_abs_idx = _offset + len(result)
-            result.extend(_flatten_steps(children, _offset=first_child_abs_idx))
-            result.append({
-                "_type": "repeat",
-                "repeat_count": step.get("repeat_count", 1),
-                "steps_back": first_child_abs_idx,
-            })
+            children = _flatten_steps(step.get("steps", []))
+            count = step.get("repeat_count", 1)
+            # Duplicate the (already-expanded) children once per repetition. A
+            # large repeat_count produces a correspondingly long step list, but
+            # that is unambiguous for every device.
+            for rep in range(1, count + 1):
+                for child in children:
+                    result.append(_annotate_rep(copy.deepcopy(child), rep, count))
 
     return result
 
@@ -81,15 +98,6 @@ def _build_fit_bytes(
 
     for step in flat_steps:
         msg = WorkoutStepMessage()
-
-        if step["_type"] == "repeat":
-            msg.duration_type = WorkoutStepDuration.REPEAT_UNTIL_STEPS_CMPLT
-            msg.duration_value = step["steps_back"]
-            msg.target_type = WorkoutStepTarget.OPEN
-            msg.target_value = step["repeat_count"]
-            msg.intensity = Intensity.ACTIVE
-            builder.add(msg)
-            continue
 
         dur = step.get("duration", {})
         if dur.get("type") == "time":

--- a/tests/unit/test_fit_workout_exporter.py
+++ b/tests/unit/test_fit_workout_exporter.py
@@ -76,6 +76,16 @@ class TestFlattenSteps:
         assert flat[0]["notes"] == "Hard effort (#1/2)"
         assert flat[1]["notes"] == "Hard effort (#2/2)"
 
+    def test_rep_counter_survives_long_notes(self):
+        # A note at/over the 50-char FIT limit must still end with the rep marker
+        # (the original note is truncated to make room), not have it cut off.
+        long_note = "x" * 60
+        flat = _flatten_steps([_repeat(3, [_step(notes=long_note)])])
+        for rep in range(1, 4):
+            notes = flat[rep - 1]["notes"]
+            assert len(notes) <= 50
+            assert notes.endswith(f"(#{rep}/3)")
+
     def test_nested_repeats(self):
         # outer 3 x (inner 2 x step) = 6 steps
         inner = _repeat(2, [_step()])

--- a/tests/unit/test_fit_workout_exporter.py
+++ b/tests/unit/test_fit_workout_exporter.py
@@ -45,63 +45,56 @@ class TestFlattenSteps:
     def test_empty_list(self):
         assert _flatten_steps([]) == []
 
-    def test_repeat_inserts_loop_marker_after_children(self):
+    def test_no_repeat_markers_emitted(self):
+        # Flattening must never leave a "repeat" marker behind — every entry is a step.
+        flat = _flatten_steps([_repeat(3, [_step(seconds=60), _step(step_type="recovery", seconds=30)])])
+        assert all(f["_type"] == "step" for f in flat)
+
+    def test_repeat_duplicates_children(self):
         block = _repeat(3, [_step(seconds=60), _step(step_type="recovery", seconds=30)])
         flat = _flatten_steps([block])
-        # 2 child steps + 1 repeat marker = 3 total
-        assert len(flat) == 3
-        assert flat[0]["_type"] == "step"
-        assert flat[1]["_type"] == "step"
-        assert flat[2]["_type"] == "repeat"
-        assert flat[2]["repeat_count"] == 3
-        assert flat[2]["steps_back"] == 0  # first child is at absolute index 0
+        # 2 children x 3 reps = 6 expanded steps
+        assert len(flat) == 6
+        # order: active, recovery, active, recovery, active, recovery
+        assert [f["step_type"] for f in flat] == [
+            "active", "recovery", "active", "recovery", "active", "recovery",
+        ]
 
-    def test_repeat_steps_back_correct_for_single_child(self):
-        block = _repeat(5, [_step()])
-        flat = _flatten_steps([block])
-        assert flat[1]["steps_back"] == 0  # first child is at absolute index 0
+    def test_repeat_single_child(self):
+        flat = _flatten_steps([_repeat(5, [_step()])])
+        assert len(flat) == 5
+        assert all(f["_type"] == "step" for f in flat)
+
+    def test_rep_counter_appended_to_notes(self):
+        flat = _flatten_steps([_repeat(3, [_step()])])
+        assert flat[0]["notes"] == "(#1/3)"
+        assert flat[1]["notes"] == "(#2/3)"
+        assert flat[2]["notes"] == "(#3/3)"
+
+    def test_rep_counter_preserves_existing_notes(self):
+        flat = _flatten_steps([_repeat(2, [_step(notes="Hard effort")])])
+        assert flat[0]["notes"] == "Hard effort (#1/2)"
+        assert flat[1]["notes"] == "Hard effort (#2/2)"
 
     def test_nested_repeats(self):
+        # outer 3 x (inner 2 x step) = 6 steps
         inner = _repeat(2, [_step()])
         outer = _repeat(3, [inner])
         flat = _flatten_steps([outer])
-        # flat: [step(0), INNER_REPEAT(1), OUTER_REPEAT(2)]
-        assert len(flat) == 3
-        assert flat[-1]["repeat_count"] == 3
-        # Both inner and outer start at step 0 — no preceding steps
-        assert flat[1]["steps_back"] == 0  # inner repeat: first child at index 0
-        assert flat[2]["steps_back"] == 0  # outer repeat: first child at index 0
-
-    def test_nested_repeat_with_preceding_step_uses_absolute_index(self):
-        # Flat: [step_a(0), step_b(1), INNER_REPEAT(2), OUTER_REPEAT(3)]
-        # INNER_REPEAT must point to step_b at absolute index 1, not local index 0.
-        flat = _flatten_steps([_step(), _repeat(3, [_repeat(2, [_step()])])])
-        assert len(flat) == 4
-        inner_repeat = flat[2]
-        outer_repeat = flat[3]
-        assert inner_repeat["_type"] == "repeat"
-        assert outer_repeat["_type"] == "repeat"
-        # Both should point to step_b at absolute index 1
-        assert inner_repeat["steps_back"] == 1
-        assert outer_repeat["steps_back"] == 1
+        assert len(flat) == 6
+        assert all(f["_type"] == "step" for f in flat)
 
     def test_mixed_steps_and_repeat(self):
         flat = _flatten_steps([_step(), _repeat(2, [_step()]), _step()])
-        assert len(flat) == 4  # warmup + (1 step + 1 repeat marker) + cooldown
+        # warmup + (1 child x 2 reps) + cooldown = 4 steps
+        assert len(flat) == 4
+        assert all(f["_type"] == "step" for f in flat)
 
-    def test_repeat_steps_back_is_first_child_absolute_index_not_child_count(self):
-        # [step(0), repeat_children_start(1), repeat_child(1), REPEAT_marker]
-        # steps_back must be 1 (first child absolute index), not 1 (coincidence here)
-        # Use a case where they differ: two preceding steps, two children.
-        # Flat: [step(0), step(1), child_a(2), child_b(3), REPEAT]
-        # steps_back (child count) = 2, first_child_idx = 2 — same here too!
-        # Use: [step(0), child_a(1), child_b(2), REPEAT] — preceding=1, children=2.
-        # steps_back (child count) = 2, first_child_idx = 1 — different!
+    def test_multiple_children_preceded_by_step(self):
         flat = _flatten_steps([_step(), _repeat(3, [_step(), _step()])])
-        # flat: [step(0), child_a(1), child_b(2), REPEAT(3)]
-        repeat = flat[3]
-        assert repeat["_type"] == "repeat"
-        assert repeat["steps_back"] == 1  # absolute index of first child, not child count (2)
+        # 1 preceding step + (2 children x 3 reps) = 7 steps
+        assert len(flat) == 7
+        assert all(f["_type"] == "step" for f in flat)
 
 
 class TestFitWorkoutExporter:
@@ -184,7 +177,7 @@ class TestFitWorkoutExporter:
         result = exporter.export([block], "Intervals", None, 250, None)
         assert isinstance(result, bytes)
 
-    def test_repeat_count_encoded(self):
+    def test_repeat_flattened_no_marker(self):
         exporter = FitWorkoutExporter()
         block = _repeat(3, [
             _step(seconds=1200, spec={"type": "pct_ftp", "pct": 90}),
@@ -192,14 +185,13 @@ class TestFitWorkoutExporter:
         ])
         data = exporter.export([block], "3x20", None, 250, None)
         decoded = _decode_steps(data)
-        repeat_step = next(s for s in decoded if s.get("duration_type") == "repeat_until_steps_cmplt")
-        assert repeat_step.get("repeat_steps") == 3
-        assert repeat_step.get("duration_step") == 0  # first child is at absolute index 0
+        # No native repeat marker — the block is expanded into 2 x 3 = 6 steps.
+        assert not any(s.get("duration_type") == "repeat_until_steps_cmplt" for s in decoded)
+        assert len(decoded) == 6
 
-    def test_repeat_only_workout_duration_step_is_zero(self):
-        # Flat layout: [active(0), recovery(1), REPEAT(2)]
-        # The repeat marker must reference step index 0 (where the block starts),
-        # not the child-step count (2). Wahoo uses duration_step as an absolute index.
+    def test_repeat_only_workout_expands_to_step_sequence(self):
+        # The block [active, recovery] repeated 3x becomes 6 sequential steps,
+        # alternating active/recovery, with no loop-back marker.
         exporter = FitWorkoutExporter()
         block = _repeat(3, [
             _step(seconds=60, spec={"type": "pct_ftp", "pct": 120}),
@@ -207,13 +199,13 @@ class TestFitWorkoutExporter:
         ])
         data = exporter.export([block], "Intervals", None, 250, None)
         decoded = _decode_steps(data)
-        repeat_step = next(s for s in decoded if s.get("duration_type") == "repeat_until_steps_cmplt")
-        assert repeat_step["duration_step"] == 0  # first child is at absolute index 0
+        assert len(decoded) == 6
+        assert [s["intensity"] for s in decoded] == [
+            "active", "recovery", "active", "recovery", "active", "recovery",
+        ]
 
-    def test_repeat_after_warmup_duration_step_is_one(self):
-        # Flat layout: [warmup(0), active(1), recovery(2), REPEAT(3)]
-        # The repeat marker must reference step index 1 (the active step),
-        # not 2 (the child-step count). Offset warmup proves the index is absolute.
+    def test_repeat_after_warmup_expands_in_order(self):
+        # warmup + 5x(active+recovery) → 1 + 10 = 11 sequential steps.
         exporter = FitWorkoutExporter()
         steps = [
             _step(step_type="warmup", seconds=600),
@@ -224,12 +216,15 @@ class TestFitWorkoutExporter:
         ]
         data = exporter.export(steps, "Warmup + Intervals", None, 250, None)
         decoded = _decode_steps(data)
-        repeat_step = next(s for s in decoded if s.get("duration_type") == "repeat_until_steps_cmplt")
-        assert repeat_step["duration_step"] == 1  # first child is at absolute index 1
+        assert len(decoded) == 11
+        assert decoded[0]["intensity"] == "warmup"
+        assert all(s.get("duration_type") != "repeat_until_steps_cmplt" for s in decoded)
+        # rep counters present on the repeated steps
+        assert decoded[1]["notes"].endswith("(#1/5)")
+        assert decoded[-1]["notes"].endswith("(#5/5)")
 
-    def test_full_structured_workout_repeat_encodes_correct_step_index(self):
-        # Flat layout: [warmup(0), active(1), recovery(2), REPEAT(3), cooldown(4)]
-        # The repeat marker must reference step index 1, not 2.
+    def test_full_structured_workout_expands_block(self):
+        # warmup + 3x(active+recovery) + cooldown → 1 + 6 + 1 = 8 steps.
         exporter = FitWorkoutExporter()
         steps = [
             _step(step_type="warmup", seconds=600),
@@ -241,9 +236,23 @@ class TestFitWorkoutExporter:
         ]
         data = exporter.export(steps, "Full Workout", None, 250, None)
         decoded = _decode_steps(data)
-        repeat_step = next(s for s in decoded if s.get("duration_type") == "repeat_until_steps_cmplt")
-        assert repeat_step["duration_step"] == 1  # first child is at absolute index 1
-        assert repeat_step["repeat_steps"] == 3
+        assert len(decoded) == 8
+        assert decoded[0]["intensity"] == "warmup"
+        assert decoded[-1]["intensity"] == "cooldown"
+        assert not any(s.get("duration_type") == "repeat_until_steps_cmplt" for s in decoded)
+
+    def test_nested_repeat_expands_fully(self):
+        # outer 3 x (inner 2 x active) = 6 active steps, no markers.
+        exporter = FitWorkoutExporter()
+        steps = [
+            _repeat(3, [
+                _repeat(2, [_step(seconds=60, spec={"type": "pct_ftp", "pct": 110})]),
+            ]),
+        ]
+        data = exporter.export(steps, "Nested", None, 250, None)
+        decoded = _decode_steps(data)
+        assert len(decoded) == 6
+        assert all(s.get("duration_type") != "repeat_until_steps_cmplt" for s in decoded)
 
     def test_export_distance_duration(self):
         exporter = FitWorkoutExporter()

--- a/tests/unit/test_fit_workout_round_trip.py
+++ b/tests/unit/test_fit_workout_round_trip.py
@@ -54,28 +54,32 @@ class TestRoundTrip:
         ]
         decoded = _decode(_export(steps, "5x2min"))
 
-        # Flat layout: warmup(0), active(1), recovery(2), REPEAT(3), cooldown(4)
-        assert len(decoded) == 5
+        # Flattened layout: warmup(0) + 5x(active, recovery) + cooldown = 12 steps
+        assert len(decoded) == 12
+        assert not any(s.get("duration_type") == "repeat_until_steps_cmplt" for s in decoded)
 
-        warmup, active, recovery, repeat, cooldown = decoded
+        warmup, cooldown = decoded[0], decoded[-1]
 
         assert warmup["intensity"] == "warmup"
         assert warmup["duration_type"] == "time"
         assert warmup["duration_time"] == pytest.approx(600.0)
 
-        assert active["intensity"] == "active"
-        assert active["duration_type"] == "time"
-        assert active["duration_time"] == pytest.approx(120.0)
-        assert active["target_type"] == "power"
-        assert active["custom_target_power_low"] == 100
-        assert active["custom_target_power_high"] == 100
+        # The 5 active/recovery pairs occupy indices 1..10.
+        for rep in range(5):
+            active = decoded[1 + rep * 2]
+            recovery = decoded[2 + rep * 2]
 
-        assert recovery["intensity"] == "recovery"
-        assert recovery["duration_time"] == pytest.approx(60.0)
+            assert active["intensity"] == "active"
+            assert active["duration_type"] == "time"
+            assert active["duration_time"] == pytest.approx(120.0)
+            assert active["target_type"] == "power"
+            assert active["custom_target_power_low"] == 100
+            assert active["custom_target_power_high"] == 100
+            assert active["notes"].endswith(f"(#{rep + 1}/5)")
 
-        assert repeat["duration_type"] == "repeat_until_steps_cmplt"
-        assert repeat["duration_step"] == 1   # first child (active) is at absolute index 1
-        assert repeat["repeat_steps"] == 5
+            assert recovery["intensity"] == "recovery"
+            assert recovery["duration_time"] == pytest.approx(60.0)
+            assert recovery["notes"].endswith(f"(#{rep + 1}/5)")
 
         assert cooldown["intensity"] == "cooldown"
         assert cooldown["duration_time"] == pytest.approx(600.0)
@@ -93,15 +97,14 @@ class TestRoundTrip:
         ]
         decoded = _decode(_export(steps, "3x5min"))
 
-        assert len(decoded) == 3
-        assert decoded[0]["intensity"] == "active"
+        # [active, recovery] x 3 = 6 flattened steps, no repeat marker.
+        assert len(decoded) == 6
+        assert not any(s.get("duration_type") == "repeat_until_steps_cmplt" for s in decoded)
+        assert [s["intensity"] for s in decoded] == [
+            "active", "recovery", "active", "recovery", "active", "recovery",
+        ]
         assert decoded[0]["target_type"] == "power"
         assert decoded[0]["target_power_zone"] == 4
-
-        repeat = decoded[2]
-        assert repeat["duration_type"] == "repeat_until_steps_cmplt"
-        assert repeat["duration_step"] == 0
-        assert repeat["repeat_steps"] == 3
 
     def test_multiple_repeat_blocks(self):
         """Two back-to-back repeat blocks — second block's marker must reference correct index."""
@@ -127,18 +130,15 @@ class TestRoundTrip:
         ]
         decoded = _decode(_export(steps, "Mixed"))
 
-        # Flat: warmup(0), active1(1), rec1(2), REPEAT1(3), active2(4), rec2(5), REPEAT2(6), cooldown(7)
-        assert len(decoded) == 8
-
-        repeat1 = decoded[3]
-        assert repeat1["duration_type"] == "repeat_until_steps_cmplt"
-        assert repeat1["duration_step"] == 1
-        assert repeat1["repeat_steps"] == 3
-
-        repeat2 = decoded[6]
-        assert repeat2["duration_type"] == "repeat_until_steps_cmplt"
-        assert repeat2["duration_step"] == 4
-        assert repeat2["repeat_steps"] == 2
+        # Flattened: warmup + 3x(active,recovery) + 2x(active,recovery) + cooldown
+        # = 1 + 6 + 4 + 1 = 12 steps, no repeat markers.
+        assert len(decoded) == 12
+        assert not any(s.get("duration_type") == "repeat_until_steps_cmplt" for s in decoded)
+        assert decoded[0]["intensity"] == "warmup"
+        assert decoded[-1]["intensity"] == "cooldown"
+        # First block reps run 60s active; second block reps run 300s active.
+        assert decoded[1]["duration_time"] == pytest.approx(60.0)
+        assert decoded[7]["duration_time"] == pytest.approx(300.0)
 
     def test_hr_absolute_target_round_trip(self):
         """HR absolute targets encode into custom_target_heart_rate_low/high, not target_value."""
@@ -182,7 +182,7 @@ class TestRoundTrip:
         assert decoded[0]["custom_target_power_high"] == 1250
 
     def test_nested_repeat_round_trip(self):
-        """Nested repeat: inner marker must point to the correct absolute step index."""
+        """Nested repeat flattens to outer x inner copies of the inner steps."""
         steps = [
             {"kind": "step", "step_type": "warmup",
              "duration": {"type": "time", "seconds": 300}},
@@ -195,18 +195,11 @@ class TestRoundTrip:
         ]
         decoded = _decode(_export(steps, "Nested"))
 
-        # Flat: warmup(0), active(1), INNER_REPEAT(2), OUTER_REPEAT(3)
-        assert len(decoded) == 4
-
-        inner_repeat = decoded[2]
-        assert inner_repeat["duration_type"] == "repeat_until_steps_cmplt"
-        assert inner_repeat["duration_step"] == 1   # active is at absolute index 1
-        assert inner_repeat["repeat_steps"] == 2
-
-        outer_repeat = decoded[3]
-        assert outer_repeat["duration_type"] == "repeat_until_steps_cmplt"
-        assert outer_repeat["duration_step"] == 1   # outer block also starts at active (index 1)
-        assert outer_repeat["repeat_steps"] == 3
+        # Flattened: warmup + (3 x 2 = 6 active steps) = 7 steps, no markers.
+        assert len(decoded) == 7
+        assert not any(s.get("duration_type") == "repeat_until_steps_cmplt" for s in decoded)
+        assert decoded[0]["intensity"] == "warmup"
+        assert all(s["intensity"] == "active" for s in decoded[1:])
 
 
 # ---------------------------------------------------------------------------
@@ -228,8 +221,9 @@ class TestDescribeFitWorkout:
         output = describe_fit_workout(_export(steps, "W"))
         assert "2 steps" in output
 
-    def test_repeat_marker_shows_target_step_and_count(self):
-        """The description must make the repeat target index and count immediately visible."""
+    def test_repeat_block_flattened_in_description(self):
+        """Repeat blocks are flattened, so the description lists every expanded step
+        (warmup + 4x(active,recovery) = 9 steps) and contains no repeat marker."""
         steps = [
             {"kind": "step", "step_type": "warmup", "duration": {"type": "time", "seconds": 300}},
             {"kind": "repeat", "repeat_count": 4, "steps": [
@@ -240,9 +234,9 @@ class TestDescribeFitWorkout:
             ]},
         ]
         output = describe_fit_workout(_export(steps, "Intervals"))
-        # Repeat marker should reference step 1 (active) and repeat 4 times
-        assert "→1" in output
-        assert "×4" in output
+        assert "9 steps" in output
+        # No native repeat loop-back marker remains.
+        assert "→" not in output
 
     def test_power_pct_ftp_shown_in_description(self):
         steps = [{"kind": "step", "step_type": "active",


### PR DESCRIPTION
## Summary

Fixes #73 — workouts exported to Wahoo devices rendered repeat blocks incorrectly.

The FIT exporter previously encoded repeat blocks using the native FIT `REPEAT_UNTIL_STEPS_CMPLT` "loop-back" marker. Wahoo devices render that marker incorrectly regardless of how the back-reference index is computed — despite three prior rounds of index fixes (`a4410e6`, `42e9a92`, `1a62e1f`), the bug kept coming back.

This PR stops fighting the marker entirely and instead **flattens repeat blocks into a literal sequence of duplicated steps**, which is unambiguous for every device.

## Changes

- **`openkoutsi/workout_formats/fit_workout.py`**
  - `_flatten_steps` now expands each repeat block into `repeat_count` copies of its (already-expanded) child steps, recursively for nested repeats. No repeat markers are emitted.
  - Each duplicated step gets a compact `(#rep/count)` marker appended to its notes so the rider can tell intervals apart on-device (e.g. a 5×(active+recovery) block → 10 steps tagged `(#1/5)`…`(#5/5)`).
  - Removed the now-dead repeat branch in `_build_fit_bytes`; `num_valid_steps` already derives from the expanded list length.
- **Tests** — rewrote the repeat-marker assertions in `test_fit_workout_exporter.py` and `test_fit_workout_round_trip.py` to assert the flattened layout (e.g. warmup + 5×(active,recovery) + cooldown → 12 sequential steps, no loop marker, rep counters in notes). Updated the one `describe_fit_workout` test that expected a marker.
- **`README.md`** — one-line note that FIT export flattens repeat blocks for reliable device display.

`fit_debug.py` keeps its `repeat_until_steps_cmplt` handling so it can still describe FIT files produced elsewhere.

## Trade-off

A large `repeat_count` produces a correspondingly longer step list (e.g. 20×(active+recovery) → 40 steps). This is intentional: correctness and device compatibility over compactness.

## Verification

The pure-Python `_flatten_steps`/`_annotate_rep` logic was verified locally (duplication, note preservation, nesting, deepcopy isolation, mixed steps, empty case). The FIT byte-encoding tests require `fit-tool`, which couldn't be installed in the sandbox (no network) — relying on CI to run the full `uv run python -m pytest tests/` suite.

https://claude.ai/code/session_01M3Q9pQASbPThadzfZELoKv

---
_Generated by [Claude Code](https://claude.ai/code/session_01M3Q9pQASbPThadzfZELoKv)_