### PR TITLE
Add FTP estimation from power curve

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Most cycling coaching tools are cloud-only SaaS. openkoutsi is different: you ru
 - **Workout categorization** — automatic Coggan-style zone classification with manual override
 - **Strava + Wahoo sync** — OAuth integrations with history import and webhook updates through bridge services
 - **Zone sync** — sync HR/power zones and FTP from connected providers
+- **FTP estimation** — estimate FTP from your power curve via the 20-minute (95%) or Critical Power method, shown on the Power view, and accept either to set your profile FTP
 - **Fitness metrics** — CTL/ATL/TSB computed and shown as interactive charts; stale metrics caused by deleted activities are detected and corrected automatically on dashboard load
 - **Training calendar** — dashboard calendar shows both performed and planned workouts with distinct visual markers
 - **Training plan generation** — periodized plans (Base → Build → Peak → Taper)

--- a/backend/app/api/athlete.py
+++ b/backend/app/api/athlete.py
@@ -163,7 +163,7 @@ async def update_athlete(
         tests.append({
             "date": datetime.now(timezone.utc).date().isoformat(),
             "ftp": body.ftp,
-            "method": "manual",
+            "method": body.ftp_test_method or "manual",
         })
         athlete.ftp_tests = tests
     if body.max_hr is not None:

--- a/backend/app/api/power.py
+++ b/backend/app/api/power.py
@@ -8,8 +8,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.app.core.deps import get_ctx_and_session
 from backend.app.models.team_orm import Activity, ActivityPowerBest, Athlete, WeightLog
-from backend.app.schemas.power import AllTimePowerBestsResponse, PowerBestEntry
-from openkoutsi.training_math import POWER_BEST_DURATIONS
+from backend.app.schemas.power import AllTimePowerBestsResponse, FtpEstimateResponse, PowerBestEntry
+from openkoutsi.training_math import (
+    CP_FIT_DURATIONS,
+    POWER_BEST_DURATIONS,
+    estimate_cp_wprime,
+    estimate_ftp_simple,
+)
 
 router = APIRouter(prefix="/power", tags=["power"])
 
@@ -102,3 +107,60 @@ async def get_power_bests(
     entries.sort(key=lambda e: (duration_order.get(e.duration_s, 9999), e.rank))
 
     return AllTimePowerBestsResponse(bests=entries)
+
+
+@router.get("/ftp-estimate", response_model=FtpEstimateResponse)
+async def get_ftp_estimate(
+    days: Optional[int] = Query(None, ge=1, description="Estimate from bests in the past N days. Omit for all-time."),
+    ctx_session=Depends(get_ctx_and_session),
+):
+    """
+    Estimate FTP from the athlete's power curve using two methods:
+
+    - Simple: 95% of the 20-minute (1200s) best power.
+    - Critical Power: linear work–time fit over the 2–20 minute bests (CP).
+
+    Both estimates use the rank-1 (single best) power per duration.  Pass
+    ?days=90/180/365 to estimate from a rolling window; omit for all-time.
+    """
+    ctx, session = ctx_session
+    athlete = await _get_athlete(ctx.user_id, session)
+
+    cutoff = (
+        datetime.now(timezone.utc) - timedelta(days=days)
+        if days is not None
+        else None
+    )
+
+    where_clauses = [
+        ActivityPowerBest.athlete_id == athlete.id,
+        ActivityPowerBest.duration_s.in_(CP_FIT_DURATIONS),
+    ]
+    if cutoff is not None:
+        where_clauses.append(ActivityPowerBest.activity_start_time >= cutoff)
+
+    rows = await session.execute(
+        select(ActivityPowerBest.duration_s, ActivityPowerBest.power_w)
+        .where(*where_clauses)
+        .order_by(ActivityPowerBest.duration_s, ActivityPowerBest.power_w.desc())
+    )
+
+    # Keep the single best (rank-1) power per duration.
+    rank1: dict[int, float] = {}
+    for duration_s, power_w in rows.all():
+        if duration_s not in rank1:
+            rank1[duration_s] = power_w
+
+    twenty_min_power = rank1.get(1200)
+    ftp_simple_raw = estimate_ftp_simple(twenty_min_power)
+    cp, w_prime = estimate_cp_wprime(rank1)
+
+    return FtpEstimateResponse(
+        twenty_min_power=round(twenty_min_power, 1) if twenty_min_power is not None else None,
+        ftp_simple=round(ftp_simple_raw) if ftp_simple_raw is not None else None,
+        simple_available=ftp_simple_raw is not None,
+        cp=round(cp, 1) if cp is not None else None,
+        w_prime=round(w_prime) if w_prime is not None else None,
+        ftp_cp=round(cp) if cp is not None else None,
+        cp_available=cp is not None,
+    )

--- a/backend/app/schemas/athlete.py
+++ b/backend/app/schemas/athlete.py
@@ -57,6 +57,7 @@ class AthleteUpdate(BaseModel):
     hr_zones: Optional[list[ZoneSchema]] = None
     power_zones: Optional[list[ZoneSchema]] = None
     app_settings: Optional[dict] = None
+    ftp_test_method: Optional[str] = None
 
 
 class TrainingStatusBody(BaseModel):

--- a/backend/app/schemas/athlete.py
+++ b/backend/app/schemas/athlete.py
@@ -1,5 +1,5 @@
 from datetime import date, datetime
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel, field_validator
 
@@ -57,7 +57,7 @@ class AthleteUpdate(BaseModel):
     hr_zones: Optional[list[ZoneSchema]] = None
     power_zones: Optional[list[ZoneSchema]] = None
     app_settings: Optional[dict] = None
-    ftp_test_method: Optional[str] = None
+    ftp_test_method: Optional[Literal["manual", "20min", "cp"]] = None
 
 
 class TrainingStatusBody(BaseModel):

--- a/backend/app/schemas/power.py
+++ b/backend/app/schemas/power.py
@@ -16,3 +16,13 @@ class PowerBestEntry(BaseModel):
 
 class AllTimePowerBestsResponse(BaseModel):
     bests: list[PowerBestEntry]
+
+
+class FtpEstimateResponse(BaseModel):
+    twenty_min_power: Optional[float] = None  # rank-1 1200s best, watts
+    ftp_simple: Optional[int] = None          # round(0.95 * twenty_min_power)
+    simple_available: bool = False
+    cp: Optional[float] = None                # critical power, watts
+    w_prime: Optional[float] = None           # anaerobic work capacity, joules
+    ftp_cp: Optional[int] = None              # round(cp) — FTP = CP directly
+    cp_available: bool = False

--- a/frontend/messages/en/app.json
+++ b/frontend/messages/en/app.json
@@ -7,7 +7,14 @@
     "loading": "Loading…",
     "noData": "No power data yet. Upload a workout with a power meter to see your bests.",
     "noWeight": "no weight",
-    "rangeAll": "All"
+    "rangeAll": "All",
+    "ftpEstimate": "FTP Estimate",
+    "ftpSimple": "20-min method (95%)",
+    "ftpComplex": "Critical Power model",
+    "ftpAccept": "Accept",
+    "ftpAccepted": "FTP set to {ftp} W",
+    "ftpInsufficientData": "Not enough data",
+    "ftpCpDetail": "CP {cp} W · W′ {wprime} kJ"
   },
   "records": {
     "title": "Distance Records",

--- a/frontend/messages/fi/app.json
+++ b/frontend/messages/fi/app.json
@@ -7,7 +7,14 @@
     "loading": "Ladataan…",
     "noData": "Ei tehodataa vielä. Lataa harjoitus tehomittarilla nähdäksesi parhaat tuloksesi.",
     "noWeight": "ei painoa",
-    "rangeAll": "Kaikki"
+    "rangeAll": "Kaikki",
+    "ftpEstimate": "FTP-arvio",
+    "ftpSimple": "20 min -menetelmä (95 %)",
+    "ftpComplex": "Kriittisen tehon malli",
+    "ftpAccept": "Hyväksy",
+    "ftpAccepted": "FTP asetettu arvoon {ftp} W",
+    "ftpInsufficientData": "Ei riittävästi dataa",
+    "ftpCpDetail": "CP {cp} W · W′ {wprime} kJ"
   },
   "records": {
     "title": "Matkaennätykset",

--- a/frontend/src/app/[locale]/t/[slug]/(app)/power/page.tsx
+++ b/frontend/src/app/[locale]/t/[slug]/(app)/power/page.tsx
@@ -5,8 +5,11 @@ import { useParams } from 'next/navigation'
 import { Link } from '@/navigation'
 import useSWR from 'swr'
 import { useTranslations } from 'next-intl'
-import { fetcher } from '@/lib/api'
-import type { AllTimePowerBests, PowerBestEntry } from '@/lib/types'
+import { fetcher, apiFetch } from '@/lib/api'
+import { useAuth } from '@/lib/auth'
+import { toast } from '@/components/ui/use-toast'
+import type { AllTimePowerBests, FtpEstimate, PowerBestEntry } from '@/lib/types'
+import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { PowerCurveChart, formatDuration } from '@/components/charts/PowerCurveChart'
 
@@ -68,6 +71,115 @@ const RANGE_OPTIONS = [
   { label: '6M',  days: 180 },
   { label: '3M',  days: 90  },
 ] as const
+
+function FtpEstimateRow({
+  label,
+  detail,
+  value,
+  available,
+  onAccept,
+  accepting,
+}: {
+  label: string
+  detail?: string
+  value: number | null
+  available: boolean
+  onAccept: () => void
+  accepting: boolean
+}) {
+  const t = useTranslations('app')
+  return (
+    <div className="flex items-center justify-between gap-4 py-3">
+      <div>
+        <div className="font-medium">{label}</div>
+        {available && detail && (
+          <div className="text-xs text-muted-foreground">{detail}</div>
+        )}
+      </div>
+      <div className="flex items-center gap-3">
+        {available && value != null ? (
+          <>
+            <span className="text-lg font-semibold tabular-nums">{value} W</span>
+            <Button size="sm" variant="outline" disabled={accepting} onClick={onAccept}>
+              {t('power.ftpAccept')}
+            </Button>
+          </>
+        ) : (
+          <span className="text-sm text-muted-foreground">{t('power.ftpInsufficientData')}</span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function FtpEstimateCard({ rangeDays }: { rangeDays: number | null }) {
+  const t = useTranslations('app')
+  const tCommon = useTranslations('common')
+  const { refreshAthlete } = useAuth()
+  const [accepting, setAccepting] = useState<string | null>(null)
+
+  const ftpKey = rangeDays != null
+    ? `/api/power/ftp-estimate?days=${rangeDays}`
+    : '/api/power/ftp-estimate'
+  const { data: ftp, isLoading } = useSWR<FtpEstimate>(ftpKey, fetcher)
+
+  async function accept(value: number, method: 'cp' | '20min') {
+    setAccepting(method)
+    try {
+      await apiFetch('/api/athlete/', {
+        method: 'PUT',
+        body: JSON.stringify({ ftp: value, ftp_test_method: method }),
+      })
+      await refreshAthlete()
+      toast({ title: t('power.ftpAccepted', { ftp: value }) })
+    } catch (err) {
+      toast({
+        title: tCommon('error'),
+        description: err instanceof Error ? err.message : tCommon('unknownError'),
+        variant: 'destructive',
+      })
+    } finally {
+      setAccepting(null)
+    }
+  }
+
+  const cpDetail = ftp?.cp != null && ftp?.w_prime != null
+    ? t('power.ftpCpDetail', { cp: Math.round(ftp.cp), wprime: (ftp.w_prime / 1000).toFixed(1) })
+    : undefined
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">{t('power.ftpEstimate')}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="flex h-24 items-center justify-center text-sm text-muted-foreground">
+            {t('power.loading')}
+          </div>
+        ) : (
+          <div className="divide-y">
+            <FtpEstimateRow
+              label={t('power.ftpSimple')}
+              value={ftp?.ftp_simple ?? null}
+              available={!!ftp?.simple_available}
+              accepting={accepting === '20min'}
+              onAccept={() => ftp?.ftp_simple != null && accept(ftp.ftp_simple, '20min')}
+            />
+            <FtpEstimateRow
+              label={t('power.ftpComplex')}
+              detail={cpDetail}
+              value={ftp?.ftp_cp ?? null}
+              available={!!ftp?.cp_available}
+              accepting={accepting === 'cp'}
+              onAccept={() => ftp?.ftp_cp != null && accept(ftp.ftp_cp, 'cp')}
+            />
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
 
 export default function PowerPage() {
   const t = useTranslations('app')
@@ -134,6 +246,9 @@ export default function PowerPage() {
           )}
         </CardContent>
       </Card>
+
+      {/* FTP estimate */}
+      <FtpEstimateCard rangeDays={rangeDays} />
 
       {/* Power all-time bests */}
       <Card>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -277,6 +277,16 @@ export interface AllTimePowerBests {
   bests: PowerBestEntry[]
 }
 
+export interface FtpEstimate {
+  twenty_min_power: number | null
+  ftp_simple: number | null
+  simple_available: boolean
+  cp: number | null
+  w_prime: number | null
+  ftp_cp: number | null
+  cp_available: boolean
+}
+
 export interface DistanceBestEntry {
   distance_m: number
   rank: number

--- a/openapi.json
+++ b/openapi.json
@@ -4919,7 +4919,12 @@
           "ftp_test_method": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "string",
+                "enum": [
+                  "manual",
+                  "20min",
+                  "cp"
+                ]
               },
               {
                 "type": "null"

--- a/openapi.json
+++ b/openapi.json
@@ -3025,6 +3025,64 @@
         }
       }
     },
+    "/api/power/ftp-estimate": {
+      "get": {
+        "tags": [
+          "power"
+        ],
+        "summary": "Get Ftp Estimate",
+        "description": "Estimate FTP from the athlete's power curve using two methods:\n\n- Simple: 95% of the 20-minute (1200s) best power.\n- Critical Power: linear work\u2013time fit over the 2\u201320 minute bests (CP).\n\nBoth estimates use the rank-1 (single best) power per duration.  Pass\n?days=90/180/365 to estimate from a rolling window; omit for all-time.",
+        "operationId": "get_ftp_estimate_api_power_ftp_estimate_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Estimate from bests in the past N days. Omit for all-time.",
+              "title": "Days"
+            },
+            "description": "Estimate from bests in the past N days. Omit for all-time."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FtpEstimateResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/plans/": {
       "get": {
         "tags": [
@@ -4857,6 +4915,17 @@
               }
             ],
             "title": "App Settings"
+          },
+          "ftp_test_method": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ftp Test Method"
           }
         },
         "type": "object",
@@ -5184,6 +5253,77 @@
           "analysis"
         ],
         "title": "FrontendAnalysisBody"
+      },
+      "FtpEstimateResponse": {
+        "properties": {
+          "twenty_min_power": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Twenty Min Power"
+          },
+          "ftp_simple": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ftp Simple"
+          },
+          "simple_available": {
+            "type": "boolean",
+            "title": "Simple Available",
+            "default": false
+          },
+          "cp": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cp"
+          },
+          "w_prime": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "W Prime"
+          },
+          "ftp_cp": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ftp Cp"
+          },
+          "cp_available": {
+            "type": "boolean",
+            "title": "Cp Available",
+            "default": false
+          }
+        },
+        "type": "object",
+        "title": "FtpEstimateResponse"
       },
       "FtpTestSchema": {
         "properties": {

--- a/openkoutsi/training_math.py
+++ b/openkoutsi/training_math.py
@@ -39,6 +39,59 @@ def compute_power_bests(stream: list[float]) -> dict[int, float]:
     }
 
 
+# Durations (seconds) used for the Critical Power fit: 2–20 minutes.
+CP_FIT_DURATIONS: list[int] = [120, 180, 300, 480, 900, 1200]
+
+
+def estimate_ftp_simple(twenty_min_power: float | None) -> float | None:
+    """
+    Simple FTP estimate: 95% of the 20-minute (1200s) best mean power.
+    Returns None if no 20-minute best is available.
+    """
+    if twenty_min_power is None:
+        return None
+    return 0.95 * twenty_min_power
+
+
+def estimate_cp_wprime(bests: dict[int, float]) -> tuple[float | None, float | None]:
+    """
+    Estimate Critical Power (CP) and anaerobic work capacity (W') from the
+    2–20 minute power bests using the linear work–time model.
+
+    For each duration t (seconds) with mean power P(t) watts, total work is
+    W(t) = P(t)·t joules.  The model W(t) = CP·t + W' is fit by ordinary
+    least squares; the slope is CP (watts) and the intercept is W' (joules).
+
+    `bests` maps duration_s -> mean power (watts); only durations in
+    CP_FIT_DURATIONS are used.  Needs at least 2 data points.  Returns
+    (None, None) if there are fewer than 2 points or the fit yields CP <= 0.
+    """
+    points = [
+        (float(d), bests[d] * d)  # (t, work)
+        for d in CP_FIT_DURATIONS
+        if d in bests
+    ]
+    if len(points) < 2:
+        return None, None
+
+    n = len(points)
+    sum_t = sum(t for t, _ in points)
+    sum_w = sum(w for _, w in points)
+    sum_tt = sum(t * t for t, _ in points)
+    sum_tw = sum(t * w for t, w in points)
+
+    denom = n * sum_tt - sum_t * sum_t
+    if denom == 0:
+        return None, None
+
+    cp = (n * sum_tw - sum_t * sum_w) / denom
+    w_prime = (sum_w - cp * sum_t) / n
+
+    if cp <= 0:
+        return None, None
+    return cp, w_prime
+
+
 # Distance best durations in metres
 DISTANCE_BEST_DISTANCES: list[int] = [
     1_000, 2_000, 3_000, 5_000, 8_000,

--- a/tests/integration/test_athlete.py
+++ b/tests/integration/test_athlete.py
@@ -47,6 +47,25 @@ class TestUpdateAthlete:
         assert data["ftp_tests"][0]["ftp"] == 280
         assert data["ftp_tests"][0]["method"] == "manual"
 
+    async def test_ftp_test_method_recorded_when_provided(self, client, auth_headers):
+        resp = await client.put(
+            "/api/athlete/",
+            json={"ftp": 265, "ftp_test_method": "20min"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ftp_tests"][-1]["method"] == "20min"
+
+    async def test_ftp_test_method_ignored_without_ftp(self, client, auth_headers):
+        resp = await client.put(
+            "/api/athlete/",
+            json={"max_hr": 190, "ftp_test_method": "cp"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["ftp_tests"] == []
+
     async def test_updating_ftp_twice_preserves_history(self, client, auth_headers):
         await client.put("/api/athlete/", json={"ftp": 250}, headers=auth_headers)
         resp = await client.put("/api/athlete/", json={"ftp": 280}, headers=auth_headers)

--- a/tests/integration/test_athlete.py
+++ b/tests/integration/test_athlete.py
@@ -57,6 +57,14 @@ class TestUpdateAthlete:
         data = resp.json()
         assert data["ftp_tests"][-1]["method"] == "20min"
 
+    async def test_invalid_ftp_test_method_rejected(self, client, auth_headers):
+        resp = await client.put(
+            "/api/athlete/",
+            json={"ftp": 265, "ftp_test_method": "xyz"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 422
+
     async def test_ftp_test_method_ignored_without_ftp(self, client, auth_headers):
         resp = await client.put(
             "/api/athlete/",

--- a/tests/integration/test_power.py
+++ b/tests/integration/test_power.py
@@ -303,3 +303,81 @@ class TestPowerBestsFromFitFile:
         # All entries must link back to the uploaded activity
         for entry in bests:
             assert entry["activity_id"] == activity_id
+
+
+class TestGetFtpEstimate:
+    async def test_empty_for_new_athlete(self, client, auth_headers):
+        resp = await client.get("/api/power/ftp-estimate", headers=auth_headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ftp_simple"] is None
+        assert body["ftp_cp"] is None
+        assert body["simple_available"] is False
+        assert body["cp_available"] is False
+
+    async def test_unauthenticated_returns_401(self, client):
+        resp = await client.get("/api/power/ftp-estimate")
+        assert resp.status_code == 401
+
+    async def test_both_methods_available_with_long_stream(
+        self, client, auth_headers, session
+    ):
+        athlete = await _get_athlete(client, auth_headers, session)
+        # 1300s of constant 250 W covers all CP durations (120–1200).
+        await _insert_activity_with_power(
+            session, athlete, [250.0] * 1300, "2025-06-01T10:00:00+00:00"
+        )
+
+        resp = await client.get("/api/power/ftp-estimate", headers=auth_headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["simple_available"] is True
+        assert body["twenty_min_power"] == pytest.approx(250.0, abs=0.1)
+        assert body["ftp_simple"] == round(0.95 * 250.0)
+        assert body["cp_available"] is True
+        # Constant power → CP ≈ 250 W, W' ≈ 0 J.
+        assert body["cp"] == pytest.approx(250.0, abs=0.5)
+        assert body["w_prime"] == pytest.approx(0.0, abs=1.0)
+        assert body["ftp_cp"] == 250
+
+    async def test_cp_available_without_20min(self, client, auth_headers, session):
+        athlete = await _get_athlete(client, auth_headers, session)
+        # 500s stream: covers 120/180/300/480 (>=2 CP points) but not 1200.
+        await _insert_activity_with_power(
+            session, athlete, [250.0] * 500, "2025-06-02T10:00:00+00:00"
+        )
+
+        resp = await client.get("/api/power/ftp-estimate", headers=auth_headers)
+        body = resp.json()
+        assert body["simple_available"] is False
+        assert body["ftp_simple"] is None
+        assert body["cp_available"] is True
+        assert body["ftp_cp"] is not None
+
+    async def test_neither_available_with_short_stream(
+        self, client, auth_headers, session
+    ):
+        athlete = await _get_athlete(client, auth_headers, session)
+        # 130s stream covers only the 120s CP duration → fewer than 2 points.
+        await _insert_activity_with_power(
+            session, athlete, [250.0] * 130, "2025-06-03T10:00:00+00:00"
+        )
+
+        resp = await client.get("/api/power/ftp-estimate", headers=auth_headers)
+        body = resp.json()
+        assert body["simple_available"] is False
+        assert body["cp_available"] is False
+
+    async def test_days_filter_excludes_old_activity(
+        self, client, auth_headers, session
+    ):
+        athlete = await _get_athlete(client, auth_headers, session)
+        old = datetime.now(timezone.utc) - timedelta(days=200)
+        await _insert_activity_with_power(
+            session, athlete, [250.0] * 1300, old.isoformat()
+        )
+
+        resp = await client.get("/api/power/ftp-estimate?days=90", headers=auth_headers)
+        body = resp.json()
+        assert body["simple_available"] is False
+        assert body["cp_available"] is False

--- a/tests/unit/test_power_analysis.py
+++ b/tests/unit/test_power_analysis.py
@@ -5,8 +5,11 @@ Unit tests for peak_average_power and compute_power_bests in training_math.py.
 import pytest
 
 from openkoutsi.training_math import (
+    CP_FIT_DURATIONS,
     POWER_BEST_DURATIONS,
     compute_power_bests,
+    estimate_cp_wprime,
+    estimate_ftp_simple,
     peak_average_power,
 )
 
@@ -109,3 +112,60 @@ class TestComputePowerBests:
         stream = [300.0] * 28800
         bests = compute_power_bests(stream)
         assert set(bests.keys()) == set(POWER_BEST_DURATIONS)
+
+
+class TestEstimateFtpSimple:
+    def test_returns_95_percent_of_20min_power(self):
+        assert estimate_ftp_simple(300.0) == pytest.approx(285.0)
+
+    def test_returns_none_when_no_power(self):
+        assert estimate_ftp_simple(None) is None
+
+
+class TestEstimateCpWPrime:
+    def test_recovers_known_cp_and_wprime(self):
+        # Construct bests exactly on the line P(t) = CP + W'/t, so the
+        # work–time OLS fit must recover CP and W' exactly.
+        cp_true, w_prime_true = 250.0, 15000.0
+        bests = {d: cp_true + w_prime_true / d for d in CP_FIT_DURATIONS}
+        cp, w_prime = estimate_cp_wprime(bests)
+        assert cp == pytest.approx(cp_true)
+        assert w_prime == pytest.approx(w_prime_true)
+
+    def test_two_points_exact_fit(self):
+        cp_true, w_prime_true = 220.0, 12000.0
+        bests = {120: cp_true + w_prime_true / 120, 1200: cp_true + w_prime_true / 1200}
+        cp, w_prime = estimate_cp_wprime(bests)
+        assert cp == pytest.approx(cp_true)
+        assert w_prime == pytest.approx(w_prime_true)
+
+    def test_constant_power_yields_zero_wprime(self):
+        bests = {d: 250.0 for d in CP_FIT_DURATIONS}
+        cp, w_prime = estimate_cp_wprime(bests)
+        assert cp == pytest.approx(250.0)
+        assert w_prime == pytest.approx(0.0, abs=1e-6)
+
+    def test_single_point_returns_none(self):
+        assert estimate_cp_wprime({1200: 250.0}) == (None, None)
+
+    def test_empty_returns_none(self):
+        assert estimate_cp_wprime({}) == (None, None)
+
+    def test_ignores_durations_outside_fit_range(self):
+        # 1s and 28800s are not CP fit durations; only the two CP points count.
+        cp_true, w_prime_true = 240.0, 10000.0
+        bests = {
+            1: 900.0,
+            300: cp_true + w_prime_true / 300,
+            900: cp_true + w_prime_true / 900,
+            28800: 180.0,
+        }
+        cp, w_prime = estimate_cp_wprime(bests)
+        assert cp == pytest.approx(cp_true)
+        assert w_prime == pytest.approx(w_prime_true)
+
+    def test_non_physical_cp_returns_none(self):
+        # Decreasing work with time forces a negative slope (CP <= 0).
+        bests = {120: 1000.0, 1200: 50.0}
+        cp, w_prime = estimate_cp_wprime(bests)
+        assert cp is None and w_prime is None


### PR DESCRIPTION
## Summary

Estimate FTP from the athlete's power curve using two methods, show both on the Power view, and let the user accept either to set their profile FTP.

- **Simple** — FTP = 95% of the 20-minute (1200s) best power.
- **Critical Power** — linear work–time model fit over the 2–20 minute bests (`W(t) = CP·t + W'`, closed-form OLS, no new dependencies). CP is used directly as the FTP estimate; `CP` and `W'` are surfaced for transparency.

## Backend

- `openkoutsi/training_math.py`: `estimate_ftp_simple`, `estimate_cp_wprime`, `CP_FIT_DURATIONS`.
- New `GET /power/ftp-estimate` endpoint (`FtpEstimateResponse`) with optional `?days` window, using the rank-1 best per duration and availability flags.
- `AthleteUpdate` gains an optional `ftp_test_method`, so accepted estimates are recorded in `ftp_tests` as `"20min"`/`"cp"` (defaults to `"manual"`, backward compatible).

## Frontend

- FTP estimate card on the Power view with **Accept** buttons that PUT the chosen FTP and refresh the athlete app-wide.
- Shows "Not enough data" when bests are missing; CP row shows `CP / W′`.
- EN + FI translations added.

## Tests & docs

- Unit tests for the estimation math (known-value CP/W' recovery, edge cases).
- Integration tests for the endpoint (both/one/neither method available, `?days` filtering) and for recording the FTP test method.
- `openapi.json` and `README.md` updated.

## Verification note

The sandbox blocks pip/npm downloads, so the full `pytest`/`vitest` suites could not be run locally — CI will exercise them. Verified locally: the pure-Python CP/FTP math against known-value cases, `py_compile` on all changed backend/test files, and frontend import/i18n resolution.

https://claude.ai/code/session_01WU6qck83kqxvfjiSFtSJAT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WU6qck83kqxvfjiSFtSJAT)_