### PR TITLE
feat: mark planned workouts as skipped with reason

### DIFF
--- a/backend/app/db/migrations/team/versions/005_planned_workout_skip_reason.py
+++ b/backend/app/db/migrations/team/versions/005_planned_workout_skip_reason.py
@@ -1,0 +1,33 @@
+"""Add skip_reason column to planned_workouts table.
+
+Revision ID: 005_planned_workout_skip_reason
+Revises: 004_goal_outcome_note
+Create Date: 2026-06-06
+
+Idempotent: safe to run against DBs that already have this column.
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import text
+
+revision = "005_planned_workout_skip_reason"
+down_revision = "004_goal_outcome_note"
+branch_labels = None
+depends_on = None
+
+
+def _column_exists(conn, table_name: str, column_name: str) -> bool:
+    rows = conn.execute(text(f'PRAGMA table_info("{table_name}")')).fetchall()
+    return any(row[1] == column_name for row in rows)
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if not _column_exists(conn, "planned_workouts", "skip_reason"):
+        op.add_column("planned_workouts", sa.Column("skip_reason", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    if _column_exists(conn, "planned_workouts", "skip_reason"):
+        op.drop_column("planned_workouts", "skip_reason")

--- a/backend/app/db/team_session.py
+++ b/backend/app/db/team_session.py
@@ -46,20 +46,3 @@ async def init_team_db(team_id: str) -> None:
     async with engine.begin() as conn:
         await conn.execute(text("PRAGMA journal_mode=WAL"))
         await conn.run_sync(TeamBase.metadata.create_all)
-        # Schema migrations for columns added after initial release
-        await _apply_schema_migrations(conn)
-
-
-async def _apply_schema_migrations(conn) -> None:
-    """Add columns that were introduced after create_all first ran on existing DBs."""
-    migrations = [
-        "ALTER TABLE planned_workouts ADD COLUMN skip_reason TEXT",
-    ]
-    for stmt in migrations:
-        try:
-            await conn.execute(text(stmt))
-        except Exception as exc:
-            # SQLite raises OperationalError: "duplicate column name: <col>" when the
-            # column already exists — that is the only expected failure; re-raise anything else.
-            if "duplicate column name" not in str(exc).lower():
-                raise

--- a/backend/main.py
+++ b/backend/main.py
@@ -20,8 +20,22 @@ log = logging.getLogger(__name__)
 async def lifespan(app: FastAPI):
     from backend.app.api.strava import strava_bridge_poller
     from backend.app.api.wahoo import wahoo_bridge_poller
+    from sqlalchemy import select
+    from backend.app.models.registry_orm import Team
+    from backend.app.db.registry import _RegistrySessionLocal
+    from backend.app.db.team_session import init_team_db
 
     await init_registry_db()
+
+    # Run schema migrations for every existing team DB on startup
+    async with _RegistrySessionLocal() as reg_session:
+        result = await reg_session.execute(select(Team))
+        teams = result.scalars().all()
+    for team in teams:
+        try:
+            await init_team_db(team.id)
+        except Exception:
+            log.exception("Failed to migrate team DB for team %s", team.id)
 
     strava_poller = asyncio.create_task(strava_bridge_poller())
     wahoo_poller = asyncio.create_task(wahoo_bridge_poller())

--- a/backend/main.py
+++ b/backend/main.py
@@ -20,22 +20,8 @@ log = logging.getLogger(__name__)
 async def lifespan(app: FastAPI):
     from backend.app.api.strava import strava_bridge_poller
     from backend.app.api.wahoo import wahoo_bridge_poller
-    from sqlalchemy import select
-    from backend.app.models.registry_orm import Team
-    from backend.app.db.registry import _RegistrySessionLocal
-    from backend.app.db.team_session import init_team_db
 
     await init_registry_db()
-
-    # Run schema migrations for every existing team DB on startup
-    async with _RegistrySessionLocal() as reg_session:
-        result = await reg_session.execute(select(Team))
-        teams = result.scalars().all()
-    for team in teams:
-        try:
-            await init_team_db(team.id)
-        except Exception:
-            log.exception("Failed to migrate team DB for team %s", team.id)
 
     strava_poller = asyncio.create_task(strava_bridge_poller())
     wahoo_poller = asyncio.create_task(wahoo_bridge_poller())


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds ability to mark a planned workout as skipped with a preset reason (illness, injury, fatigue, too busy, feeling lazy, travel, weather) or free-text via "Other"
- Stable keys are stored in the DB (locale-independent); labels are translated for display in the UI
- Amber "Skipped" badge shown on the workout card; reason displayed below description with a "Clear" button to undo
- When a workout is neither completed nor skipped, the plan calendar dialog shows two stacked full-width buttons: "Mark as completed…" and "Mark as skipped…"
- Alembic migration `005_planned_workout_skip_reason` adds the `skip_reason` column to `planned_workouts`

## API changes

| Method | Path | Description |
|--------|------|-------------|
| `PUT` | `/api/plans/{plan_id}/workouts/{workout_id}/skip` | Set skip reason (409 if already completed) |
| `DELETE` | `/api/plans/{plan_id}/workouts/{workout_id}/skip` | Clear skip reason |

## Migration

```
TEAM_ID=<id> alembic -c backend/alembic-team.ini upgrade head
```

## Test plan

- [ ] Open a pending workout → two stacked buttons appear: "Mark as completed…" and "Mark as skipped…"
- [ ] Click "Mark as skipped…" → select "Illness" → confirm → amber "Skipped" badge appears, buttons disappear
- [ ] Reopen → "Clear" button visible → click → back to pending state
- [ ] Select "Other" → free-text textarea appears → submit → reason stored as typed
- [ ] Attempt to skip an already-completed workout via API → 409
- [ ] `pytest tests/integration/test_plans.py -v` passes (including new `TestSkipWorkout` class)

Closes #95

https://claude.ai/code/session_01PDUWzwkWqVWpmCiD7wWwGz
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDUWzwkWqVWpmCiD7wWwGz)_