### PR TITLE
fix: recover training status stuck in pending state

### DIFF
--- a/backend/app/api/activities.py
+++ b/backend/app/api/activities.py
@@ -1,6 +1,6 @@
 import asyncio
 import uuid
-from datetime import date, datetime, time, timedelta
+from datetime import date, datetime, time, timedelta, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -79,6 +79,7 @@ def _maybe_auto_training_status(athlete: Athlete, team_id: str) -> None:
         from backend.app.services.llm_training_status_analyzer import analyze_training_status_bg
         athlete.training_status_status = "pending"
         athlete.training_status = None
+        athlete.training_status_pending_since = datetime.now(timezone.utc)
         asyncio.create_task(analyze_training_status_bg(athlete.id, team_id))
 
 

--- a/backend/app/api/activities.py
+++ b/backend/app/api/activities.py
@@ -74,13 +74,20 @@ def _maybe_auto_analyze(activity_id: str, athlete: Athlete, team_id: str) -> boo
     return False
 
 
-def _maybe_auto_training_status(athlete: Athlete, team_id: str) -> None:
+def _maybe_auto_training_status(athlete: Athlete, team_id: str) -> bool:
+    """Marks athlete as pending for training status analysis if eligible.
+
+    Returns True if the status was set to pending; caller must commit the
+    session and then call asyncio.create_task(analyze_training_status_bg(...))
+    *after* the commit to avoid a race where the task writes "error" before the
+    pending state is persisted.
+    """
     if (athlete.app_settings or {}).get("auto_training_status") and athlete.training_status_status != "pending":
-        from backend.app.services.llm_training_status_analyzer import analyze_training_status_bg
         athlete.training_status_status = "pending"
         athlete.training_status = None
         athlete.training_status_updated_at = datetime.now(timezone.utc)
-        asyncio.create_task(analyze_training_status_bg(athlete.id, team_id))
+        return True
+    return False
 
 
 async def _bg_process_and_recalculate(
@@ -194,8 +201,11 @@ async def _bg_process_and_recalculate(
             if _maybe_auto_analyze(target_act.id, athlete, team_id):
                 target_act.analysis_status = "pending"
 
-            _maybe_auto_training_status(athlete, team_id)
+            needs_status = _maybe_auto_training_status(athlete, team_id)
             await session.commit()
+            if needs_status:
+                from backend.app.services.llm_training_status_analyzer import analyze_training_status_bg
+                asyncio.create_task(analyze_training_status_bg(athlete.id, team_id))
             await find_and_link_workout(session, athlete_id, target_act)
             await recalculate_from(athlete_id, start_date, session)
 

--- a/backend/app/api/activities.py
+++ b/backend/app/api/activities.py
@@ -79,7 +79,7 @@ def _maybe_auto_training_status(athlete: Athlete, team_id: str) -> None:
         from backend.app.services.llm_training_status_analyzer import analyze_training_status_bg
         athlete.training_status_status = "pending"
         athlete.training_status = None
-        athlete.training_status_pending_since = datetime.now(timezone.utc)
+        athlete.training_status_updated_at = datetime.now(timezone.utc)
         asyncio.create_task(analyze_training_status_bg(athlete.id, team_id))
 
 

--- a/backend/app/api/athlete.py
+++ b/backend/app/api/athlete.py
@@ -289,6 +289,9 @@ async def get_avatar(
     return FileResponse(path)
 
 
+_PENDING_TIMEOUT_MINUTES = 30
+
+
 @router.get("/training-status", response_model=TrainingStatusResponse)
 async def get_training_status(
     ctx_session=Depends(get_ctx_and_session),
@@ -297,14 +300,26 @@ async def get_training_status(
     athlete = await _get_athlete(ctx.user_id, session)
     app_cfg = athlete.app_settings or {}
     from backend.app.services.llm_training_status_analyzer import _local_now
+    now_utc = datetime.now(timezone.utc)
     today = _local_now(app_cfg.get("timezone")).date()
     stale = (
         athlete.training_status_date is None
         or athlete.training_status_date < today
     )
+
+    # Recover from a stuck "pending" state: if the task hasn't completed within
+    # the timeout window, reset to "error" so the user can retry.
+    if athlete.training_status_status == "pending" and athlete.training_status_pending_since:
+        elapsed = now_utc - athlete.training_status_pending_since.replace(tzinfo=timezone.utc)
+        if elapsed.total_seconds() > _PENDING_TIMEOUT_MINUTES * 60:
+            athlete.training_status_status = "error"
+            athlete.training_status_pending_since = None
+            await session.commit()
+
     if app_cfg.get("auto_training_status") and stale and athlete.training_status_status != "pending":
         athlete.training_status_status = "pending"
         athlete.training_status = None
+        athlete.training_status_pending_since = now_utc
         await session.commit()
         from backend.app.services.llm_training_status_analyzer import analyze_training_status_bg
         asyncio.create_task(analyze_training_status_bg(athlete.id, ctx.team_id))
@@ -327,8 +342,10 @@ async def trigger_training_status(
     if athlete.training_status_status == "pending":
         return {"status": "pending"}
 
+    now_utc = datetime.now(timezone.utc)
     athlete.training_status_status = "pending"
     athlete.training_status = None
+    athlete.training_status_pending_since = now_utc
     await session.commit()
 
     from backend.app.services.llm_training_status_analyzer import analyze_training_status_bg

--- a/backend/app/api/athlete.py
+++ b/backend/app/api/athlete.py
@@ -309,9 +309,14 @@ async def get_training_status(
 
     # Recover from a stuck "pending" state: if the task hasn't completed within
     # the timeout window, reset to "error" so the user can retry.
-    if athlete.training_status_status == "pending" and athlete.training_status_updated_at:
-        elapsed = now_utc - athlete.training_status_updated_at.replace(tzinfo=timezone.utc)
-        if elapsed.total_seconds() > _PENDING_TIMEOUT_MINUTES * 60:
+    # A NULL updated_at with status "pending" (e.g. pre-migration row) is treated
+    # as immediately timed out.
+    if athlete.training_status_status == "pending":
+        updated_at = athlete.training_status_updated_at
+        timed_out = updated_at is None or (
+            now_utc - updated_at.replace(tzinfo=timezone.utc)
+        ).total_seconds() > _PENDING_TIMEOUT_MINUTES * 60
+        if timed_out:
             athlete.training_status_status = "error"
             athlete.training_status_updated_at = now_utc
             await session.commit()

--- a/backend/app/api/athlete.py
+++ b/backend/app/api/athlete.py
@@ -313,12 +313,18 @@ async def get_training_status(
     # as immediately timed out.
     if athlete.training_status_status == "pending":
         updated_at = athlete.training_status_updated_at
-        timed_out = updated_at is None or (
-            now_utc - updated_at.replace(tzinfo=timezone.utc)
-        ).total_seconds() > _PENDING_TIMEOUT_MINUTES * 60
+        if updated_at is not None:
+            # Normalise to UTC regardless of whether the stored value is naive or aware
+            aware = updated_at if updated_at.tzinfo else updated_at.replace(tzinfo=timezone.utc)
+            timed_out = (now_utc - aware.astimezone(timezone.utc)).total_seconds() > _PENDING_TIMEOUT_MINUTES * 60
+        else:
+            timed_out = True  # pre-migration row with no timestamp — treat as timed out
         if timed_out:
             athlete.training_status_status = "error"
             athlete.training_status_updated_at = now_utc
+            # Set training_status_date to today so stale=False and the auto-trigger
+            # doesn't immediately re-fire after this error reset.
+            athlete.training_status_date = today
             await session.commit()
 
     if app_cfg.get("auto_training_status") and stale and athlete.training_status_status != "pending":

--- a/backend/app/api/athlete.py
+++ b/backend/app/api/athlete.py
@@ -309,17 +309,17 @@ async def get_training_status(
 
     # Recover from a stuck "pending" state: if the task hasn't completed within
     # the timeout window, reset to "error" so the user can retry.
-    if athlete.training_status_status == "pending" and athlete.training_status_pending_since:
-        elapsed = now_utc - athlete.training_status_pending_since.replace(tzinfo=timezone.utc)
+    if athlete.training_status_status == "pending" and athlete.training_status_updated_at:
+        elapsed = now_utc - athlete.training_status_updated_at.replace(tzinfo=timezone.utc)
         if elapsed.total_seconds() > _PENDING_TIMEOUT_MINUTES * 60:
             athlete.training_status_status = "error"
-            athlete.training_status_pending_since = None
+            athlete.training_status_updated_at = now_utc
             await session.commit()
 
     if app_cfg.get("auto_training_status") and stale and athlete.training_status_status != "pending":
         athlete.training_status_status = "pending"
         athlete.training_status = None
-        athlete.training_status_pending_since = now_utc
+        athlete.training_status_updated_at = now_utc
         await session.commit()
         from backend.app.services.llm_training_status_analyzer import analyze_training_status_bg
         asyncio.create_task(analyze_training_status_bg(athlete.id, ctx.team_id))
@@ -345,7 +345,7 @@ async def trigger_training_status(
     now_utc = datetime.now(timezone.utc)
     athlete.training_status_status = "pending"
     athlete.training_status = None
-    athlete.training_status_pending_since = now_utc
+    athlete.training_status_updated_at = now_utc
     await session.commit()
 
     from backend.app.services.llm_training_status_analyzer import analyze_training_status_bg

--- a/backend/app/db/migrations/team/versions/006_athlete_training_status_pending_since.py
+++ b/backend/app/db/migrations/team/versions/006_athlete_training_status_pending_since.py
@@ -1,0 +1,36 @@
+"""Add training_status_pending_since column to athletes table.
+
+Revision ID: 006_athlete_training_status_pending_since
+Revises: 005_planned_workout_skip_reason
+Create Date: 2026-06-06
+
+Idempotent: safe to run against DBs that already have this column.
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import text
+
+revision = "006_athlete_training_status_pending_since"
+down_revision = "005_planned_workout_skip_reason"
+branch_labels = None
+depends_on = None
+
+
+def _column_exists(conn, table_name: str, column_name: str) -> bool:
+    rows = conn.execute(text(f'PRAGMA table_info("{table_name}")')).fetchall()
+    return any(row[1] == column_name for row in rows)
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if not _column_exists(conn, "athletes", "training_status_pending_since"):
+        op.add_column(
+            "athletes",
+            sa.Column("training_status_pending_since", sa.DateTime(timezone=True), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    if _column_exists(conn, "athletes", "training_status_pending_since"):
+        op.drop_column("athletes", "training_status_pending_since")

--- a/backend/app/db/migrations/team/versions/006_athlete_training_status_updated_at.py
+++ b/backend/app/db/migrations/team/versions/006_athlete_training_status_updated_at.py
@@ -1,6 +1,6 @@
-"""Add training_status_pending_since column to athletes table.
+"""Add training_status_updated_at column to athletes table.
 
-Revision ID: 006_athlete_training_status_pending_since
+Revision ID: 006_athlete_training_status_updated_at
 Revises: 005_planned_workout_skip_reason
 Create Date: 2026-06-06
 
@@ -10,7 +10,7 @@ from alembic import op
 import sqlalchemy as sa
 from sqlalchemy import text
 
-revision = "006_athlete_training_status_pending_since"
+revision = "006_athlete_training_status_updated_at"
 down_revision = "005_planned_workout_skip_reason"
 branch_labels = None
 depends_on = None
@@ -23,14 +23,14 @@ def _column_exists(conn, table_name: str, column_name: str) -> bool:
 
 def upgrade() -> None:
     conn = op.get_bind()
-    if not _column_exists(conn, "athletes", "training_status_pending_since"):
+    if not _column_exists(conn, "athletes", "training_status_updated_at"):
         op.add_column(
             "athletes",
-            sa.Column("training_status_pending_since", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("training_status_updated_at", sa.DateTime(timezone=True), nullable=True),
         )
 
 
 def downgrade() -> None:
     conn = op.get_bind()
-    if _column_exists(conn, "athletes", "training_status_pending_since"):
-        op.drop_column("athletes", "training_status_pending_since")
+    if _column_exists(conn, "athletes", "training_status_updated_at"):
+        op.drop_column("athletes", "training_status_updated_at")

--- a/backend/app/models/team_orm.py
+++ b/backend/app/models/team_orm.py
@@ -50,7 +50,7 @@ class Athlete(TeamBase):
     training_status: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     training_status_status: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     training_status_date: Mapped[Optional[date]] = mapped_column(Date, nullable=True)
-    training_status_pending_since: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    training_status_updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now)
     updated_at: Mapped[datetime] = mapped_column(

--- a/backend/app/models/team_orm.py
+++ b/backend/app/models/team_orm.py
@@ -50,6 +50,7 @@ class Athlete(TeamBase):
     training_status: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     training_status_status: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     training_status_date: Mapped[Optional[date]] = mapped_column(Date, nullable=True)
+    training_status_pending_since: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now)
     updated_at: Mapped[datetime] = mapped_column(

--- a/backend/app/services/llm_training_status_analyzer.py
+++ b/backend/app/services/llm_training_status_analyzer.py
@@ -255,107 +255,133 @@ async def analyze_training_status_bg(
     Background task: stream LLM training status → write chunks to DB every 500 ms
     → set final training_status_status to 'done' or 'error'.
     """
-    async with get_team_session_factory(team_id)() as session:
-        athlete_result = await session.execute(
-            select(Athlete).where(Athlete.id == athlete_id)
-        )
-        athlete = athlete_result.scalar_one()
-
-        app_cfg = athlete.app_settings or {}
-        resolved_locale = locale or app_cfg.get("locale")
-        coaching_style = app_cfg.get("coaching_style")
-        now = _local_now(app_cfg.get("timezone"))
-        today = now.date()
-        window_start = today - timedelta(days=28)
-
-        # Last 28 days of activities
-        acts_result = await session.execute(
-            select(Activity)
-            .where(
-                Activity.athlete_id == athlete_id,
-                Activity.start_time >= datetime(
-                    window_start.year, window_start.month, window_start.day,
-                    tzinfo=timezone.utc,
-                ),
+    try:
+        async with get_team_session_factory(team_id)() as session:
+            athlete_result = await session.execute(
+                select(Athlete).where(Athlete.id == athlete_id)
             )
-            .order_by(Activity.start_time.asc())
-        )
-        recent_activities = list(acts_result.scalars().all())
+            athlete = athlete_result.scalar_one()
 
-        # Latest DailyMetric
-        metric_result = await session.execute(
-            select(DailyMetric)
-            .where(DailyMetric.athlete_id == athlete_id)
-            .order_by(DailyMetric.date.desc())
-            .limit(1)
-        )
-        current_metric = metric_result.scalar_one_or_none()
+            app_cfg = athlete.app_settings or {}
+            resolved_locale = locale or app_cfg.get("locale")
+            coaching_style = app_cfg.get("coaching_style")
+            now = _local_now(app_cfg.get("timezone"))
+            today = now.date()
+            window_start = today - timedelta(days=28)
 
-        # Active training plan
-        plan_result = await session.execute(
-            select(TrainingPlan)
-            .where(
-                TrainingPlan.athlete_id == athlete_id,
-                TrainingPlan.status == "active",
-            )
-            .order_by(TrainingPlan.created_at.desc())
-            .limit(1)
-        )
-        active_plan = plan_result.scalar_one_or_none()
-
-        # This week's planned workouts (if plan exists)
-        this_week_workouts: list[PlannedWorkout] = []
-        if active_plan and active_plan.start_date:
-            current_week = max(1, (today - active_plan.start_date).days // 7 + 1)
-            pw_result = await session.execute(
-                select(PlannedWorkout)
+            # Last 28 days of activities
+            acts_result = await session.execute(
+                select(Activity)
                 .where(
-                    PlannedWorkout.plan_id == active_plan.id,
-                    PlannedWorkout.week_number == current_week,
+                    Activity.athlete_id == athlete_id,
+                    Activity.start_time >= datetime(
+                        window_start.year, window_start.month, window_start.day,
+                        tzinfo=timezone.utc,
+                    ),
                 )
-                .order_by(PlannedWorkout.day_of_week)
+                .order_by(Activity.start_time.asc())
             )
-            this_week_workouts = list(pw_result.scalars().all())
+            recent_activities = list(acts_result.scalars().all())
 
-        # Active goals
-        goals_result = await session.execute(
-            select(Goal)
-            .where(
-                Goal.athlete_id == athlete_id,
-                Goal.status == "active",
+            # Latest DailyMetric
+            metric_result = await session.execute(
+                select(DailyMetric)
+                .where(DailyMetric.athlete_id == athlete_id)
+                .order_by(DailyMetric.date.desc())
+                .limit(1)
             )
-            .order_by(Goal.target_date.asc().nullslast())
+            current_metric = metric_result.scalar_one_or_none()
+
+            # Active training plan
+            plan_result = await session.execute(
+                select(TrainingPlan)
+                .where(
+                    TrainingPlan.athlete_id == athlete_id,
+                    TrainingPlan.status == "active",
+                )
+                .order_by(TrainingPlan.created_at.desc())
+                .limit(1)
+            )
+            active_plan = plan_result.scalar_one_or_none()
+
+            # This week's planned workouts (if plan exists)
+            this_week_workouts: list[PlannedWorkout] = []
+            if active_plan and active_plan.start_date:
+                current_week = max(1, (today - active_plan.start_date).days // 7 + 1)
+                pw_result = await session.execute(
+                    select(PlannedWorkout)
+                    .where(
+                        PlannedWorkout.plan_id == active_plan.id,
+                        PlannedWorkout.week_number == current_week,
+                    )
+                    .order_by(PlannedWorkout.day_of_week)
+                )
+                this_week_workouts = list(pw_result.scalars().all())
+
+            # Active goals
+            goals_result = await session.execute(
+                select(Goal)
+                .where(
+                    Goal.athlete_id == athlete_id,
+                    Goal.status == "active",
+                )
+                .order_by(Goal.target_date.asc().nullslast())
+            )
+            active_goals = list(goals_result.scalars().all())
+
+            buffer: list[str] = []
+            last_flush = time.monotonic()
+            accumulated = ""
+
+            try:
+                async for chunk in _stream_status_analysis(
+                    athlete, team_id,
+                    recent_activities, current_metric,
+                    active_plan, this_week_workouts, active_goals,
+                    now, locale=resolved_locale, coaching_style=coaching_style,
+                ):
+                    buffer.append(chunk)
+                    if time.monotonic() - last_flush >= 0.5:
+                        accumulated += "".join(buffer)
+                        buffer.clear()
+                        last_flush = time.monotonic()
+                        athlete.training_status = accumulated
+                        await session.commit()
+
+                accumulated += "".join(buffer)
+                athlete.training_status = accumulated
+                athlete.training_status_status = "done"
+                athlete.training_status_date = today
+                athlete.training_status_pending_since = None
+                await session.commit()
+                log.info("Training status analysis complete for athlete %s", athlete_id)
+
+            except Exception:
+                log.exception("Training status analysis failed for athlete %s", athlete_id)
+                athlete.training_status_status = "error"
+                athlete.training_status_date = today
+                athlete.training_status_pending_since = None
+                await session.commit()
+
+    except Exception:
+        # Session acquisition or early DB query failed — open a fresh session to
+        # clear the pending state so the user can retry.
+        log.exception(
+            "Training status background task failed outside inner try for athlete %s",
+            athlete_id,
         )
-        active_goals = list(goals_result.scalars().all())
-
-        buffer: list[str] = []
-        last_flush = time.monotonic()
-        accumulated = ""
-
         try:
-            async for chunk in _stream_status_analysis(
-                athlete, team_id,
-                recent_activities, current_metric,
-                active_plan, this_week_workouts, active_goals,
-                now, locale=resolved_locale, coaching_style=coaching_style,
-            ):
-                buffer.append(chunk)
-                if time.monotonic() - last_flush >= 0.5:
-                    accumulated += "".join(buffer)
-                    buffer.clear()
-                    last_flush = time.monotonic()
-                    athlete.training_status = accumulated
-                    await session.commit()
-
-            accumulated += "".join(buffer)
-            athlete.training_status = accumulated
-            athlete.training_status_status = "done"
-            athlete.training_status_date = today
-            await session.commit()
-            log.info("Training status analysis complete for athlete %s", athlete_id)
-
+            async with get_team_session_factory(team_id)() as recovery_session:
+                result = await recovery_session.execute(
+                    select(Athlete).where(Athlete.id == athlete_id)
+                )
+                athlete = result.scalar_one_or_none()
+                if athlete:
+                    athlete.training_status_status = "error"
+                    athlete.training_status_pending_since = None
+                    await recovery_session.commit()
         except Exception:
-            log.exception("Training status analysis failed for athlete %s", athlete_id)
-            athlete.training_status_status = "error"
-            athlete.training_status_date = today
-            await session.commit()
+            log.exception(
+                "Recovery session also failed for athlete %s — status may remain stuck",
+                athlete_id,
+            )

--- a/backend/app/services/llm_training_status_analyzer.py
+++ b/backend/app/services/llm_training_status_analyzer.py
@@ -352,7 +352,7 @@ async def analyze_training_status_bg(
                 athlete.training_status = accumulated
                 athlete.training_status_status = "done"
                 athlete.training_status_date = today
-                athlete.training_status_pending_since = None
+                athlete.training_status_updated_at = datetime.now(timezone.utc)
                 await session.commit()
                 log.info("Training status analysis complete for athlete %s", athlete_id)
 
@@ -360,7 +360,7 @@ async def analyze_training_status_bg(
                 log.exception("Training status analysis failed for athlete %s", athlete_id)
                 athlete.training_status_status = "error"
                 athlete.training_status_date = today
-                athlete.training_status_pending_since = None
+                athlete.training_status_updated_at = datetime.now(timezone.utc)
                 await session.commit()
 
     except Exception:
@@ -378,7 +378,7 @@ async def analyze_training_status_bg(
                 athlete = result.scalar_one_or_none()
                 if athlete:
                     athlete.training_status_status = "error"
-                    athlete.training_status_pending_since = None
+                    athlete.training_status_updated_at = datetime.now(timezone.utc)
                     await recovery_session.commit()
         except Exception:
             log.exception(

--- a/backend/app/services/llm_training_status_analyzer.py
+++ b/backend/app/services/llm_training_status_analyzer.py
@@ -379,6 +379,7 @@ async def analyze_training_status_bg(
                 if athlete:
                     athlete.training_status_status = "error"
                     athlete.training_status_updated_at = datetime.now(timezone.utc)
+                    athlete.training_status_date = datetime.now(timezone.utc).date()
                     await recovery_session.commit()
         except Exception:
             log.exception(

--- a/backend/app/services/strava_sync.py
+++ b/backend/app/services/strava_sync.py
@@ -263,6 +263,7 @@ async def _process_event_for_team(
             from backend.app.services.llm_training_status_analyzer import analyze_training_status_bg
             athlete.training_status_status = "pending"
             athlete.training_status = None
+            athlete.training_status_pending_since = datetime.now(timezone.utc)
             await session.commit()
             asyncio.create_task(analyze_training_status_bg(athlete.id, team_id))
 

--- a/backend/app/services/strava_sync.py
+++ b/backend/app/services/strava_sync.py
@@ -263,7 +263,7 @@ async def _process_event_for_team(
             from backend.app.services.llm_training_status_analyzer import analyze_training_status_bg
             athlete.training_status_status = "pending"
             athlete.training_status = None
-            athlete.training_status_pending_since = datetime.now(timezone.utc)
+            athlete.training_status_updated_at = datetime.now(timezone.utc)
             await session.commit()
             asyncio.create_task(analyze_training_status_bg(athlete.id, team_id))
 

--- a/backend/app/services/wahoo_sync.py
+++ b/backend/app/services/wahoo_sync.py
@@ -254,7 +254,9 @@ async def _process_wahoo_for_team(norm, athlete, conn, access_token, team_id, se
 
     if app_cfg.get("auto_training_status") and athlete.training_status_status != "pending":
         from backend.app.services.llm_training_status_analyzer import analyze_training_status_bg
+        from datetime import datetime, timezone
         athlete.training_status_status = "pending"
         athlete.training_status = None
+        athlete.training_status_pending_since = datetime.now(timezone.utc)
         await session.commit()
         asyncio.create_task(analyze_training_status_bg(athlete.id, team_id))

--- a/backend/app/services/wahoo_sync.py
+++ b/backend/app/services/wahoo_sync.py
@@ -257,6 +257,6 @@ async def _process_wahoo_for_team(norm, athlete, conn, access_token, team_id, se
         from datetime import datetime, timezone
         athlete.training_status_status = "pending"
         athlete.training_status = None
-        athlete.training_status_pending_since = datetime.now(timezone.utc)
+        athlete.training_status_updated_at = datetime.now(timezone.utc)
         await session.commit()
         asyncio.create_task(analyze_training_status_bg(athlete.id, team_id))

--- a/tests/integration/test_athlete.py
+++ b/tests/integration/test_athlete.py
@@ -3,6 +3,7 @@ Integration tests for /api/athlete endpoints.
 """
 import io
 import json
+from datetime import datetime
 import zipfile
 from pathlib import Path
 from unittest.mock import patch
@@ -551,3 +552,34 @@ class TestTrainingStatus:
 
         assert resp.status_code == 200
         assert resp.json()["status"] == "pending"
+
+    async def test_pending_with_null_updated_at_resets_to_error(self, client, auth_headers, session):
+        from backend.app.models.team_orm import Athlete
+
+        result = await session.execute(
+            select(Athlete).where(Athlete.global_user_id == "test-user-00000000")
+        )
+        athlete = result.scalar_one()
+        athlete.training_status_status = "pending"
+        athlete.training_status_updated_at = None
+        await session.commit()
+
+        resp = await client.get("/api/athlete/training-status", headers=auth_headers)
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "error"
+
+    async def test_pending_older_than_timeout_resets_to_error(self, client, auth_headers, session):
+        from datetime import timedelta, timezone
+        from backend.app.models.team_orm import Athlete
+
+        result = await session.execute(
+            select(Athlete).where(Athlete.global_user_id == "test-user-00000000")
+        )
+        athlete = result.scalar_one()
+        athlete.training_status_status = "pending"
+        athlete.training_status_updated_at = datetime.now(timezone.utc) - timedelta(minutes=31)
+        await session.commit()
+
+        resp = await client.get("/api/athlete/training-status", headers=auth_headers)
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "error"


### PR DESCRIPTION
## Problem

The `analyze_training_status_bg` background task only caught exceptions inside its inner `try` block — after the session was already open and the athlete loaded. Any failure *before* that point (session acquisition, early DB queries failing e.g. due to a missing column from a not-yet-run migration) would propagate out uncaught, leaving `training_status_status` permanently stuck on `"pending"`. Since the GET and POST endpoints both guard on `status != "pending"`, there was no way to retry without a manual DB fix.

## Fix

**1. Outer try/except in `analyze_training_status_bg`**

The entire task body is now wrapped in an outer `try/except`. If the outer block fails (e.g. session factory throws, or an early DB query hits a missing column), a fresh recovery session is opened to set `status="error"` so the user can retry.

**2. `training_status_updated_at` timestamp + 30-minute timeout**

Added `training_status_updated_at` (nullable DateTime) to `Athlete`. It is set to `now()` on every status transition — `pending`, `done`, and `error` — in all four trigger paths (manual POST, auto-trigger GET, activity upload, Strava/Wahoo webhooks) and in the background task itself.

The GET endpoint checks this on every poll: if `status == "pending"` and either `updated_at` is `NULL` or more than 30 minutes have elapsed, the status is reset to `"error"` so the user can retry. A `NULL` `updated_at` is treated as immediately timed out — this covers rows that were stuck before the migration added the column.

**3. Alembic migration 006**

Adds the `training_status_updated_at` column to the `athletes` table, following the same idempotent pattern as existing migrations.

## Migration

```
TEAM_ID=<id> alembic -c backend/alembic-team.ini upgrade head
```

## Files changed

| File | Change |
|------|--------|
| `backend/app/models/team_orm.py` | Add `training_status_updated_at` field |
| `backend/app/db/migrations/team/versions/006_athlete_training_status_updated_at.py` | Alembic migration |
| `backend/app/services/llm_training_status_analyzer.py` | Outer try/except; set `updated_at` on done and error |
| `backend/app/api/athlete.py` | Set `updated_at` on trigger; 30-min timeout recovery on GET; NULL treated as timed out |
| `backend/app/api/activities.py` | Set `updated_at` on activity-upload trigger |
| `backend/app/services/strava_sync.py` | Set `updated_at` on Strava webhook trigger |
| `backend/app/services/wahoo_sync.py` | Set `updated_at` on Wahoo webhook trigger |

https://claude.ai/code/session_01PDUWzwkWqVWpmCiD7wWwGz