### PR TITLE
Fix frontend build type error in messages and add build step to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,12 @@ jobs:
         env:
           NEXT_PUBLIC_BASE_URL: "http://localhost:3000"
 
+      - name: Build standalone bundle
+        run: npm run build
+        env:
+          NEXT_PUBLIC_BASE_URL: "http://localhost:3000"
+          NEXT_PUBLIC_API_URL: "http://localhost:8000"
+
       - name: Upload coverage
         uses: actions/upload-artifact@v4
         with:

--- a/frontend/src/app/[locale]/superadmin/page.tsx
+++ b/frontend/src/app/[locale]/superadmin/page.tsx
@@ -291,9 +291,9 @@ export default function SuperadminPage() {
                       {!m.read_at && (
                         <span className="h-2 w-2 shrink-0 rounded-full bg-primary" aria-hidden="true" />
                       )}
-                      <p className="text-sm font-medium">{tm(`types.${key}.title` as never, values)}</p>
+                      <p className="text-sm font-medium">{tm(`types.${key}.title` as never, values as never)}</p>
                     </div>
-                    <p className="text-sm text-muted-foreground">{tm(`types.${key}.body` as never, values)}</p>
+                    <p className="text-sm text-muted-foreground">{tm(`types.${key}.body` as never, values as never)}</p>
                     <p className="text-xs text-muted-foreground">{new Date(m.created_at).toLocaleString()}</p>
                   </div>
                   <Button

--- a/frontend/src/app/[locale]/t/[slug]/(app)/inbox/page.tsx
+++ b/frontend/src/app/[locale]/t/[slug]/(app)/inbox/page.tsx
@@ -113,11 +113,11 @@ export default function InboxPage() {
                         <span className="h-2 w-2 shrink-0 rounded-full bg-primary" aria-hidden="true" />
                       )}
                       <p className="text-sm font-medium">
-                        {t(`types.${key}.title` as never, values)}
+                        {t(`types.${key}.title` as never, values as never)}
                       </p>
                     </div>
                     <p className="text-sm text-muted-foreground">
-                      {t(`types.${key}.body` as never, values)}
+                      {t(`types.${key}.body` as never, values as never)}
                     </p>
                     <p className="text-xs text-muted-foreground">
                       {new Date(m.created_at).toLocaleString()}


### PR DESCRIPTION
The dynamic i18n key cast (`as never`) collapses next-intl's inferred
values parameter type to `undefined`, so passing interpolation values
failed type checking during `next build`. Cast the values argument to
`never` (assignable to `undefined`) at the four message-rendering call
sites in the superadmin and inbox pages.

This was only caught at deploy time because CI never ran the production
build. Add a "Build standalone bundle" step to the frontend CI job so the
standalone build (output: 'standalone') runs the same way the deploy
script does, catching type errors on PRs.

https://claude.ai/code/session_01WFnGwmDWBLTLZTUMia9hab