### PR TITLE
Fix horizontal scroll on admin page with long Finnish tab labels

### DIFF
--- a/frontend/src/app/[locale]/t/[slug]/(app)/admin/page.tsx
+++ b/frontend/src/app/[locale]/t/[slug]/(app)/admin/page.tsx
@@ -784,7 +784,7 @@ export default function AdminPage() {
     <div className="max-w-4xl space-y-6">
       <h1 className="text-2xl font-semibold">{t('title')}</h1>
       <Tabs defaultValue="members">
-        <TabsList>
+        <TabsList className="max-w-full justify-start overflow-x-auto">
           <TabsTrigger value="members">{t('tabs.members')}</TabsTrigger>
           <TabsTrigger value="invitations">{t('tabs.invitations')}</TabsTrigger>
           <TabsTrigger value="joinRequests">{t('tabs.joinRequests')}</TabsTrigger>


### PR DESCRIPTION
The admin TabsList is an inline-flex strip of whitespace-nowrap tabs.
Finnish labels (e.g. "Liittymispyynnöt") make the strip wider than the
viewport, forcing the page into horizontal scroll. Constrain the tab
strip to its container width and let it scroll internally instead.