### PR TITLE
Label current week's training days with weekday and date in user timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Most cycling coaching tools are cloud-only SaaS. openkoutsi is different: you ru
 - **Goals** — set training/event goals with optional target metrics and dates; when marking a goal achieved, record the final achieved value and a free-text outcome note capturing whether the target was reached
 - **Activity labels & notes** — tag activities as "race" or "commute" and add free-text notes (included in AI analysis context)
 - **AI coaching analysis** — per-activity analysis and plan support with OpenAI-compatible backends
-- **Koutsi daily feedback** — dashboard card with LLM-generated daily training status covering load trends, recovery state, plan adherence, and goal progress; auto-triggers after uploads/syncs when enabled. The current week's planned workouts are labelled with explicit weekday names and dates in the athlete's timezone (with today marked) so Koutsi never confuses which day is which
+- **Koutsi daily feedback** — dashboard card with LLM-generated daily training status covering load trends, recovery state, plan adherence, and goal progress; auto-triggers after uploads/syncs when enabled
 - **PATCH support on `/api/athlete/`** — athlete profile endpoint now accepts both `PUT` and `PATCH` for partial updates
 - **Privacy-first** — export your data and delete your account at any time
 - **Cycling-themed 404 page** — localized "Wrong Turn!" not-found page with cycling flavour

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Most cycling coaching tools are cloud-only SaaS. openkoutsi is different: you ru
 - **Goals** — set training/event goals with optional target metrics and dates; when marking a goal achieved, record the final achieved value and a free-text outcome note capturing whether the target was reached
 - **Activity labels & notes** — tag activities as "race" or "commute" and add free-text notes (included in AI analysis context)
 - **AI coaching analysis** — per-activity analysis and plan support with OpenAI-compatible backends
-- **Koutsi daily feedback** — dashboard card with LLM-generated daily training status covering load trends, recovery state, plan adherence, and goal progress; auto-triggers after uploads/syncs when enabled
+- **Koutsi daily feedback** — dashboard card with LLM-generated daily training status covering load trends, recovery state, plan adherence, and goal progress; auto-triggers after uploads/syncs when enabled. The current week's planned workouts are labelled with explicit weekday names and dates in the athlete's timezone (with today marked) so Koutsi never confuses which day is which
 - **PATCH support on `/api/athlete/`** — athlete profile endpoint now accepts both `PUT` and `PATCH` for partial updates
 - **Privacy-first** — export your data and delete your account at any time
 - **Cycling-themed 404 page** — localized "Wrong Turn!" not-found page with cycling flavour

--- a/backend/app/services/llm_training_status_analyzer.py
+++ b/backend/app/services/llm_training_status_analyzer.py
@@ -150,12 +150,29 @@ def _build_status_prompt(
         )
         lines.append(f"  Current week: {week_num}")
         if this_week_workouts:
+            # Start of the current plan week (a rolling 7-day block from plan_start).
+            week_start = plan_start + timedelta(days=(week_num - 1) * 7)
             lines.append("  This week's planned workouts:")
             for w in this_week_workouts:
+                # Map day_of_week (1=Mon..7=Sun, isoweekday convention) to the actual
+                # calendar date within this plan week, so the weekday label is explicit
+                # and unambiguous in the athlete's local timezone.
+                workout_date = next(
+                    (
+                        week_start + timedelta(days=offset)
+                        for offset in range(7)
+                        if (week_start + timedelta(days=offset)).isoweekday()
+                        == w.day_of_week
+                    ),
+                    week_start,
+                )
+                weekday_name = workout_date.strftime("%A")
+                today_marker = " (today)" if workout_date == today else ""
                 completed = "completed" if w.completed_activity_id else "not completed"
                 tss_str = f", target TSS {w.target_tss}" if w.target_tss else ""
                 lines.append(
-                    f"    Day {w.day_of_week}: {w.workout_type or 'workout'}{tss_str} — {completed}"
+                    f"    {weekday_name} {workout_date.isoformat()}{today_marker}: "
+                    f"{w.workout_type or 'workout'}{tss_str} — {completed}"
                 )
         else:
             lines.append("  No workouts planned for this week")

--- a/tests/unit/test_llm_training_status_analyzer.py
+++ b/tests/unit/test_llm_training_status_analyzer.py
@@ -1,0 +1,78 @@
+"""Unit tests for the LLM training status prompt builder."""
+from datetime import date, datetime
+from unittest.mock import MagicMock
+from zoneinfo import ZoneInfo
+
+from backend.app.models.team_orm import Athlete, PlannedWorkout, TrainingPlan
+from backend.app.services.llm_training_status_analyzer import _build_status_prompt
+
+
+def _athlete() -> Athlete:
+    a = MagicMock(spec=Athlete)
+    a.ftp = 250
+    a.max_hr = 190
+    return a
+
+
+def _plan(start: date) -> TrainingPlan:
+    p = MagicMock(spec=TrainingPlan)
+    p.name = "Base build"
+    p.start_date = start
+    p.end_date = None
+    return p
+
+
+def _workout(day_of_week: int, **kwargs) -> PlannedWorkout:
+    w = MagicMock(spec=PlannedWorkout)
+    w.day_of_week = day_of_week
+    w.workout_type = kwargs.get("workout_type", "endurance")
+    w.target_tss = kwargs.get("target_tss", None)
+    w.completed_activity_id = kwargs.get("completed_activity_id", None)
+    return w
+
+
+class TestThisWeekWeekdayLabels:
+    def test_workouts_labelled_with_weekday_and_date(self):
+        # Plan starts Monday 2025-06-02; "now" is Wednesday 2025-06-04.
+        plan_start = date(2025, 6, 2)
+        now = datetime(2025, 6, 4, 8, 0, tzinfo=ZoneInfo("Europe/Helsinki"))
+        workouts = [
+            _workout(1, workout_type="threshold", target_tss=80),  # Monday
+            _workout(3, workout_type="intervals", target_tss=90),  # Wednesday = today
+            _workout(7, workout_type="long", target_tss=120),       # Sunday
+        ]
+        prompt = _build_status_prompt(
+            athlete=_athlete(),
+            recent_activities=[],
+            current_metric=None,
+            active_plan=_plan(plan_start),
+            this_week_workouts=workouts,
+            active_goals=[],
+            now=now,
+        )
+        # Explicit weekday names and ISO dates, not "Day 1/3/7".
+        assert "Monday 2025-06-02" in prompt
+        assert "Wednesday 2025-06-04 (today)" in prompt
+        assert "Sunday 2025-06-08" in prompt
+        assert "Day 1:" not in prompt
+
+    def test_handles_plan_starting_midweek(self):
+        # Plan starts Thursday 2025-06-05; week 1 block is Thu..Wed.
+        plan_start = date(2025, 6, 5)
+        now = datetime(2025, 6, 6, 8, 0, tzinfo=ZoneInfo("UTC"))  # Friday, week 1
+        workouts = [
+            _workout(5, workout_type="tempo"),  # Friday 2025-06-06 (today)
+            _workout(2, workout_type="rest"),   # Tuesday 2025-06-10 (next week-day in block)
+        ]
+        prompt = _build_status_prompt(
+            athlete=_athlete(),
+            recent_activities=[],
+            current_metric=None,
+            active_plan=_plan(plan_start),
+            this_week_workouts=workouts,
+            active_goals=[],
+            now=now,
+        )
+        assert "Friday 2025-06-06 (today)" in prompt
+        # Tuesday falls on the second-to-last day of the Thu..Wed block.
+        assert "Tuesday 2025-06-10" in prompt


### PR DESCRIPTION
Koutsi was occasionally confused about which day a planned workout fell
on because this week's workouts were only labelled by numeric day_of_week
("Day 1".."Day 7"). Compute each workout's actual calendar date from the
plan's rolling 7-day week block (consistent with the activity matcher) and
label it with the full weekday name and ISO date in the athlete's timezone,
marking today explicitly.

https://claude.ai/code/session_01AzFxXNWu9Wg3s88fL4MuNQ