### PR TITLE
Show cycling activity totals on dashboard fitness history card

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Most cycling coaching tools are cloud-only SaaS. openkoutsi is different: you ru
 - **Strava + Wahoo sync** — OAuth integrations with history import and webhook updates through bridge services
 - **Zone sync** — sync HR/power zones and FTP from connected providers
 - **FTP estimation** — estimate FTP from your power curve via the 20-minute (95%) or Critical Power method, shown on the Power view, and accept either to set your profile FTP
-- **Fitness metrics** — CTL/ATL/TSB computed and shown as interactive charts; stale metrics caused by deleted activities are detected and corrected automatically on dashboard load
+- **Fitness metrics** — CTL/ATL/TSB computed and shown as interactive charts; stale metrics caused by deleted activities are detected and corrected automatically on dashboard load. The fitness history card also shows cycling totals — number of activities, active time, and covered distance — for the selected time period
 - **Training calendar** — dashboard calendar shows both performed and planned workouts with distinct visual markers (completed, pending, skipped), and lets you mark a planned workout as done or skipped straight from the day view without opening the plan
 - **Training plan generation** — periodized plans (Base → Build → Peak → Taper)
 - **Activity → plan linking** — uploaded activities are automatically matched to the day's planned workout (sport, TSS ≥ 60%, duration ≥ 60%); manual link/unlink via the plan calendar or the dashboard activity calendar

--- a/backend/app/api/metrics.py
+++ b/backend/app/api/metrics.py
@@ -2,14 +2,19 @@ from datetime import date, datetime, time, timedelta
 from typing import Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.app.core.deps import get_ctx_and_session
 from backend.app.db.team_session import get_team_session_factory
 from backend.app.models.team_orm import Activity, ActivityStream, Athlete, DailyMetric
-from backend.app.schemas.metrics import FitnessCurrentResponse, FitnessMetricResponse
+from backend.app.schemas.metrics import (
+    ActivitySummaryResponse,
+    FitnessCurrentResponse,
+    FitnessMetricResponse,
+)
 from backend.app.services.metrics_engine import catch_up_metrics
+from openkoutsi.sport_matching import CYCLING_SPORT_TYPES
 from openkoutsi.zones import Zones
 
 router = APIRouter(prefix="/metrics", tags=["metrics"])
@@ -45,6 +50,42 @@ async def get_fitness(
 
     result = await session.execute(query.order_by(DailyMetric.date))
     return [FitnessMetricResponse.model_validate(m) for m in result.scalars().all()]
+
+
+@router.get("/activity-summary", response_model=ActivitySummaryResponse)
+async def get_activity_summary(
+    start: Optional[date] = Query(None),
+    end: Optional[date] = Query(None),
+    days: Optional[int] = Query(None, ge=1, le=3650),
+    ctx_session=Depends(get_ctx_and_session),
+):
+    """Totals (count, active time, distance) for cycling activities in a period."""
+    ctx, session = ctx_session
+    athlete = await _get_athlete(ctx.user_id, session)
+
+    if days is not None and start is None:
+        start = date.today() - timedelta(days=days)
+
+    query = select(
+        func.count(Activity.id),
+        func.coalesce(func.sum(Activity.duration_s), 0),
+        func.coalesce(func.sum(Activity.distance_m), 0.0),
+    ).where(
+        Activity.athlete_id == athlete.id,
+        Activity.sport_type.in_(CYCLING_SPORT_TYPES),
+    )
+
+    if start:
+        query = query.where(Activity.start_time >= datetime.combine(start, time.min))
+    if end:
+        query = query.where(Activity.start_time <= datetime.combine(end, time.max))
+
+    num, total_duration, total_distance = (await session.execute(query)).one()
+    return ActivitySummaryResponse(
+        num_activities=num,
+        total_duration_s=int(total_duration),
+        total_distance_m=float(total_distance),
+    )
 
 
 @router.get("/fitness/current", response_model=FitnessCurrentResponse)

--- a/backend/app/schemas/metrics.py
+++ b/backend/app/schemas/metrics.py
@@ -47,3 +47,11 @@ class FitnessCurrentResponse(FitnessMetricResponse):
         self.daily_tss = self.tss_day if self.daily_tss == 0.0 else self.daily_tss
         self.form = _tsb_to_form(self.tsb)
         return self
+
+
+class ActivitySummaryResponse(BaseModel):
+    """Totals for cycling activities over a selected time period."""
+
+    num_activities: int = 0
+    total_duration_s: int = 0
+    total_distance_m: float = 0.0

--- a/frontend/messages/en/dashboard.json
+++ b/frontend/messages/en/dashboard.json
@@ -15,6 +15,11 @@
   },
   "ftpValue": "{value} W",
   "fitnessHistory": "Fitness history",
+  "activitySummary": {
+    "numActivities": "Activities",
+    "activeTime": "Active time",
+    "distance": "Distance"
+  },
   "weeklyTss": "Weekly TSS",
   "weeklyTssActual": "Actual TSS",
   "weeklyTssPlanned": "Planned TSS",

--- a/frontend/messages/fi/dashboard.json
+++ b/frontend/messages/fi/dashboard.json
@@ -15,6 +15,11 @@
   },
   "ftpValue": "{value} W",
   "fitnessHistory": "Kuntohistoria",
+  "activitySummary": {
+    "numActivities": "Suoritukset",
+    "activeTime": "Aktiivinen aika",
+    "distance": "Matka"
+  },
   "weeklyTss": "Viikottainen TSS",
   "weeklyTssActual": "Toteutunut TSS",
   "weeklyTssPlanned": "Suunniteltu TSS",

--- a/frontend/src/__tests__/utils.test.ts
+++ b/frontend/src/__tests__/utils.test.ts
@@ -4,6 +4,7 @@ import {
   formatDate,
   formatDistance,
   formatDuration,
+  formatHoursMinutes,
   formatHR,
   formatPower,
 } from '@/lib/utils'
@@ -57,6 +58,15 @@ describe('formatDuration', () => {
 
   it('omits zero hours', () => {
     expect(formatDuration(120)).not.toContain('h')
+  })
+})
+
+describe('formatHoursMinutes', () => {
+  it('always shows hours and minutes', () => {
+    expect(formatHoursMinutes(45 * 60)).toBe('0h 45m')
+    expect(formatHoursMinutes(3600)).toBe('1h 0m')
+    expect(formatHoursMinutes(45296)).toBe('12h 34m')
+    expect(formatHoursMinutes(0)).toBe('0h 0m')
   })
 })
 

--- a/frontend/src/app/[locale]/t/[slug]/(app)/dashboard/page.tsx
+++ b/frontend/src/app/[locale]/t/[slug]/(app)/dashboard/page.tsx
@@ -5,7 +5,8 @@ import useSWR from 'swr'
 import { useTranslations } from 'next-intl'
 import { useAuth } from '@/lib/auth'
 import { fetcher, apiFetch } from '@/lib/api'
-import type { FitnessPoint, FitnessCurrent, TrainingPlan, TrainingStatus } from '@/lib/types'
+import type { FitnessPoint, FitnessCurrent, TrainingPlan, TrainingStatus, ActivitySummary } from '@/lib/types'
+import { formatHoursMinutes, formatDistance } from '@/lib/utils'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { FitnessChart } from '@/components/charts/FitnessChart'
@@ -188,6 +189,10 @@ export default function DashboardPage() {
     `/api/metrics/fitness?days=${days}`,
     fetcher,
   )
+  const { data: summary } = useSWR<ActivitySummary>(
+    `/api/metrics/activity-summary?days=${days}`,
+    fetcher,
+  )
   const { data: plans } = useSWR<TrainingPlan[]>('/api/plans/', fetcher)
   const activePlan = plans?.find((p) => p.status === 'active')
   const _rawPlanned = plans ? aggregatePlannedTssByWeek(plans) : undefined
@@ -264,6 +269,26 @@ export default function DashboardPage() {
             <p className="text-sm text-muted-foreground py-12 text-center">
               {t('noHistory')}
             </p>
+          )}
+          {summary && (
+            <div className="mt-4 overflow-hidden rounded-lg border border-border">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-border bg-muted/40 text-muted-foreground">
+                    <th className="px-3 py-2 text-right font-medium">{t('activitySummary.numActivities')}</th>
+                    <th className="px-3 py-2 text-right font-medium">{t('activitySummary.activeTime')}</th>
+                    <th className="px-3 py-2 text-right font-medium">{t('activitySummary.distance')}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td className="px-3 py-2 text-right tabular-nums">{summary.num_activities}</td>
+                    <td className="px-3 py-2 text-right tabular-nums">{formatHoursMinutes(summary.total_duration_s)}</td>
+                    <td className="px-3 py-2 text-right tabular-nums">{formatDistance(summary.total_distance_m)}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
           )}
         </CardContent>
       </Card>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -148,6 +148,12 @@ export interface FitnessCurrent {
   form: 'peak' | 'fresh' | 'neutral' | 'tired' | 'overreached'
 }
 
+export interface ActivitySummary {
+  num_activities: number
+  total_duration_s: number
+  total_distance_m: number
+}
+
 export interface Goal {
   id: string
   athlete_id: string

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -22,6 +22,13 @@ export function formatDuration(seconds: number): string {
   return `${s}s`
 }
 
+/** Format a duration in seconds as hours and minutes, always: 2700 → "0h 45m", 45296 → "12h 34m" */
+export function formatHoursMinutes(seconds: number): string {
+  const h = Math.floor(seconds / 3600)
+  const m = Math.floor((seconds % 3600) / 60)
+  return `${h}h ${m}m`
+}
+
 export function formatDistance(meters: number): string {
   if (meters >= 1000) return `${(meters / 1000).toFixed(1)} km`
   return `${meters.toFixed(0)} m`

--- a/openapi.json
+++ b/openapi.json
@@ -2510,6 +2510,97 @@
         }
       }
     },
+    "/api/metrics/activity-summary": {
+      "get": {
+        "tags": [
+          "metrics"
+        ],
+        "summary": "Get Activity Summary",
+        "description": "Totals (count, active time, distance) for cycling activities in a period.",
+        "operationId": "get_activity_summary_api_metrics_activity_summary_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "start",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start"
+            }
+          },
+          {
+            "name": "end",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End"
+            }
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "maximum": 3650,
+                  "minimum": 1
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Days"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitySummaryResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/metrics/fitness": {
       "get": {
         "tags": [
@@ -4550,6 +4641,27 @@
         },
         "type": "object",
         "title": "ActivityStreamsResponse"
+      },
+      "ActivitySummaryResponse": {
+        "properties": {
+          "num_activities": {
+            "type": "integer",
+            "title": "Num Activities",
+            "default": 0
+          },
+          "total_duration_s": {
+            "type": "integer",
+            "title": "Total Duration S",
+            "default": 0
+          },
+          "total_distance_m": {
+            "type": "number",
+            "title": "Total Distance M",
+            "default": 0.0
+          }
+        },
+        "type": "object",
+        "title": "ActivitySummaryResponse"
       },
       "ActivityUpdate": {
         "properties": {

--- a/openkoutsi/sport_matching.py
+++ b/openkoutsi/sport_matching.py
@@ -34,6 +34,11 @@ _ACTIVITY_SPORT_TO_CATEGORY: dict[str, str] = {
     "Badminton": "racket_sport",
 }
 
+# Sport types that count as cycling, derived from the category map above.
+CYCLING_SPORT_TYPES = frozenset(
+    sport for sport, category in _ACTIVITY_SPORT_TO_CATEGORY.items() if category == "cycling"
+)
+
 # Workout types that are sport-agnostic (apply to whatever sport the plan is for)
 _GENERIC_WORKOUT_TYPES = {
     "easy",

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -206,6 +206,80 @@ class TestRecalculate:
         assert activity.tss is not None
 
 
+# ── Activity summary ───────────────────────────────────────────────────────────
+
+class TestActivitySummary:
+    async def _add_activity(self, client, auth_headers, sport_type, start_time, duration_s, distance_m):
+        resp = await client.post(
+            "/api/activities/",
+            json={
+                "sport_type": sport_type,
+                "start_time": start_time,
+                "duration_s": duration_s,
+                "distance_m": distance_m,
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 201
+        return resp.json()["id"]
+
+    async def test_empty_for_new_athlete(self, client, auth_headers):
+        resp = await client.get("/api/metrics/activity-summary", headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data == {"num_activities": 0, "total_duration_s": 0, "total_distance_m": 0.0}
+
+    async def test_totals_only_cycling(self, client, auth_headers):
+        today = date.today()
+        recent = (today - timedelta(days=5)).isoformat() + "T10:00:00Z"
+        # Two cycling rides (counted)
+        await self._add_activity(client, auth_headers, "Ride", recent, 3600, 30000.0)
+        await self._add_activity(client, auth_headers, "VirtualRide", recent, 1800, 15000.0)
+        # Non-cycling activities (excluded)
+        await self._add_activity(client, auth_headers, "Run", recent, 1200, 5000.0)
+        await self._add_activity(client, auth_headers, "Yoga", recent, 2400, 0.0)
+
+        resp = await client.get("/api/metrics/activity-summary?days=30", headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["num_activities"] == 2
+        assert data["total_duration_s"] == 5400
+        assert data["total_distance_m"] == 45000.0
+
+    async def test_days_filter_excludes_older_activities(self, client, auth_headers):
+        today = date.today()
+        recent = (today - timedelta(days=5)).isoformat() + "T10:00:00Z"
+        old = (today - timedelta(days=120)).isoformat() + "T10:00:00Z"
+        await self._add_activity(client, auth_headers, "Ride", recent, 3600, 30000.0)
+        await self._add_activity(client, auth_headers, "Ride", old, 7200, 60000.0)
+
+        resp = await client.get("/api/metrics/activity-summary?days=30", headers=auth_headers)
+        data = resp.json()
+        assert data["num_activities"] == 1
+        assert data["total_duration_s"] == 3600
+        assert data["total_distance_m"] == 30000.0
+
+    async def test_start_and_end_range(self, client, auth_headers):
+        today = date.today()
+        in_range = (today - timedelta(days=40)).isoformat() + "T10:00:00Z"
+        out_range = (today - timedelta(days=5)).isoformat() + "T10:00:00Z"
+        await self._add_activity(client, auth_headers, "Ride", in_range, 3600, 30000.0)
+        await self._add_activity(client, auth_headers, "Ride", out_range, 1800, 15000.0)
+
+        start = str(today - timedelta(days=60))
+        end = str(today - timedelta(days=20))
+        resp = await client.get(
+            f"/api/metrics/activity-summary?start={start}&end={end}", headers=auth_headers
+        )
+        data = resp.json()
+        assert data["num_activities"] == 1
+        assert data["total_duration_s"] == 3600
+
+    async def test_unauthenticated_returns_401(self, client):
+        resp = await client.get("/api/metrics/activity-summary")
+        assert resp.status_code == 401
+
+
 # ── Zones ──────────────────────────────────────────────────────────────────────
 
 class TestZonesEndpoint:


### PR DESCRIPTION
## Summary

The dashboard's **Fitness history** card now shows a small table under the graph with three totals for the selected time period, limited to **cycling** activities:

1. **Number of activities**
2. **Active time**
3. **Covered distance**

The table updates alongside the graph when the period selector (1W–5Y) changes.

## Backend

- New endpoint `GET /api/metrics/activity-summary` (`backend/app/api/metrics.py`) accepting the same `start`/`end`/`days` params as `/api/metrics/fitness`.
- Totals are computed on the fly with a **single aggregate query** (`func.count` / `func.sum`), filtered to cycling sport types.
- Cycling sport types are reused from `openkoutsi/sport_matching.py` via a new derived `CYCLING_SPORT_TYPES` constant (`Ride`, `VirtualRide`, `GravelRide`, `MountainBikeRide`, `EBikeRide`, `EBikeSport`, `Handcycle`) — running/walking/yoga/strength/etc. are excluded.
- New `ActivitySummaryResponse` schema (`num_activities`, `total_duration_s`, `total_distance_m`).

## Frontend

- Dashboard card renders the three-column table below `FitnessChart`, fetched via SWR keyed on the same `days` state.
- Active time is **always** shown as hours and minutes (e.g. `12h 34m`, `0h 45m`) via a new `formatHoursMinutes` helper, since the existing `formatDuration` drops to `m s` below one hour.
- New `ActivitySummary` type; distance reuses `formatDistance`.
- i18n strings added for English and Finnish.

## Tests

- Backend: new `TestActivitySummary` in `tests/integration/test_metrics.py` covering cycling-only filtering, `days` window, explicit start/end range, empty athlete, and auth.
- Frontend: unit test for `formatHoursMinutes`.

> **Note:** I was unable to run the test suites in this environment — both PyPI and the npm registry are blocked by the network policy (403 Forbidden), so dependencies could not be installed. The Python sources compile cleanly (`py_compile`). Please run `uv run python -m pytest tests/` and `npx vitest run` locally to confirm.

## Docs

- README updated with a one-line note.
- `openapi.json` updated with the new path and schema (added manually to mirror the FastAPI export, since deps weren't installable here — worth regenerating via `backend/scripts/export_openapi.py` to confirm).
- No DEPLOY.md changes (no new env vars/infra).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTAA7znmd195ffu4nNgAwn)_