### PR TITLE
Fix mobile horizontal overflow in structured workout editor

### DIFF
--- a/frontend/src/components/workouts/RepeatBlockEditor.tsx
+++ b/frontend/src/components/workouts/RepeatBlockEditor.tsx
@@ -55,7 +55,7 @@ export function RepeatBlockEditor({ block, index, total, onChange, onDelete, onM
 
   return (
     <div className="border-2 border-dashed border-primary/30 rounded-md p-3 bg-primary/5 space-y-3">
-      <div className="flex items-center gap-3">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
         <Label className="text-sm font-medium">{t('repeat')}</Label>
         <Input
           type="number"
@@ -66,7 +66,7 @@ export function RepeatBlockEditor({ block, index, total, onChange, onDelete, onM
         />
         <span className="text-sm text-muted-foreground">{t('times')}</span>
 
-        <div className="flex items-center gap-1 ml-auto">
+        <div className="flex items-center gap-1 ml-auto shrink-0">
           <Button size="icon" variant="ghost" onClick={onMoveUp} disabled={index === 0}>
             <ChevronUp className="h-4 w-4" />
           </Button>

--- a/frontend/src/components/workouts/StepEditor.tsx
+++ b/frontend/src/components/workouts/StepEditor.tsx
@@ -38,7 +38,7 @@ function DurationEditor({
 }) {
   const t = useTranslations('workouts')
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex flex-wrap items-center gap-2">
       <Select
         value={duration.type}
         onValueChange={(v) => {
@@ -182,29 +182,29 @@ export function StepEditor({ step, index, total, onChange, onDelete, onMoveUp, o
 
   return (
     <div className="border rounded-md p-3 bg-background space-y-3">
-      <div className="flex items-center gap-2">
-        <Select
-          value={step.step_type}
-          onValueChange={(v) => setField('step_type', v as StepType)}
-        >
-          <SelectTrigger className="w-36">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {STEP_TYPES.map((s) => (
-              <SelectItem key={s} value={s}>{t(`stepType.${s}`)}</SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+      <div className="flex items-start gap-2">
+        <div className="flex flex-1 flex-wrap items-center gap-2 min-w-0">
+          <Select
+            value={step.step_type}
+            onValueChange={(v) => setField('step_type', v as StepType)}
+          >
+            <SelectTrigger className="w-36">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {STEP_TYPES.map((s) => (
+                <SelectItem key={s} value={s}>{t(`stepType.${s}`)}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
 
-        <div className="flex-1">
           <DurationEditor
             duration={step.duration}
             onChange={(d) => setField('duration', d)}
           />
         </div>
 
-        <div className="flex items-center gap-1 ml-auto">
+        <div className="flex items-center gap-1 shrink-0">
           <Button size="icon" variant="ghost" onClick={onMoveUp} disabled={index === 0}>
             <ChevronUp className="h-4 w-4" />
           </Button>


### PR DESCRIPTION
## Problem

When creating/editing a structured workout on mobile, some UI elements in the step editor overflowed their container, causing the whole page to scroll horizontally.

The header rows in `StepEditor` and `RepeatBlockEditor` used non-wrapping flex layouts (`flex items-center`) containing fixed-width controls — the `w-36` step-type select, the `w-32`/`w-24` duration select + input, and the three move/delete icon buttons. On narrow viewports the combined width exceeded the container and there was no `flex-wrap`, so the content spilled over and forced horizontal scrolling.

## Fix

- **`StepEditor`**: wrap the step-type select + duration editor in a `flex-1 flex-wrap min-w-0` group so they wrap onto multiple lines when space is tight, while keeping the action buttons pinned to the right with `shrink-0` so they never collapse.
- **`DurationEditor`**: add `flex-wrap` so its select/input/unit can wrap.
- **`RepeatBlockEditor`**: make the repeat-count header row `flex-wrap` (with `gap-x`/`gap-y`) and mark the action button group `shrink-0`.

These are CSS-only (Tailwind) changes — no logic or type changes.

## Testing

Could not run `npx vitest run` / typecheck in this environment: `npm` installs are blocked by the org egress policy (403 from registry.npmjs.org), so dependencies couldn't be installed. The changes are limited to Tailwind utility classes and don't alter component logic, props, or types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBRsmNsL5yTjRyzFhYLCKN)_